### PR TITLE
fix(azure): increase HTTP header size limit to prevent TooLongHttpHeaderException

### DIFF
--- a/clouddriver/clouddriver-azure/clouddriver-azure.gradle
+++ b/clouddriver/clouddriver-azure/clouddriver-azure.gradle
@@ -17,6 +17,7 @@ dependencies {
   implementation "com.azure:azure-identity:1.6.0"
   implementation "com.azure:azure-storage-blob:12.19.1"
   implementation "io.projectreactor:reactor-core"
+  implementation "io.projectreactor.netty:reactor-netty-http"
   implementation "com.google.guava:guava:31.1-jre"
 
   testImplementation "cglib:cglib-nodep"


### PR DESCRIPTION

Configure Azure HTTP client with 256KB header size limit instead of default 8KB. This prevents periodic failures when destroying Azure server groups that return large HTTP headers exceeding Netty's default limit.

Changes:
- Add custom NettyAsyncHttpClientBuilder with increased maxHeaderSize (256KB)
- Add reactor-netty-http dependency to support HTTP client configuration
- Apply fix to AzureBaseClient.initialize() method used by all Azure operations

🤖 Generated with [Claude Code](https://claude.ai/code)