### PR TITLE
Azure - remove manual server group cache evictions

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -181,6 +181,7 @@ public class AzureComputeClient extends AzureBaseClient {
       }
     } catch (Exception e) {
       log.error("getServerGroupsAll -> Unexpected exception: ${e.message}")
+      throw new RuntimeException("Failed to fetch server groups from Azure API for region: ${region}", e)
     }
 
     serverGroups

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -103,21 +103,6 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
   }
 
   CacheResult removeDeadCacheEntries(CacheResult cacheResult, ProviderCache providerCache) {
-    // Server Groups
-    def sgIdentifiers = providerCache.filterIdentifiers(AZURE_SERVER_GROUPS.ns, Keys.getServerGroupKey(AzureCloudProvider.ID, "*", region, accountName))
-    def sgCacheResults = providerCache.getAll((AZURE_SERVER_GROUPS.ns), sgIdentifiers, RelationshipCacheFilter.none())
-    def evictedSGList = sgCacheResults.collect{ cached ->
-      if (!cacheResult.cacheResults[AZURE_SERVER_GROUPS.ns].find {it.id == cached.id}) {
-        cached.id
-      } else {
-        null
-      }
-    }
-    evictedSGList.removeAll(Collections.singleton(null))
-    if (evictedSGList) {
-      cacheResult.evictions[AZURE_SERVER_GROUPS.ns] = evictedSGList
-    }
-
     // Instances
     def instanceIdentifiers = providerCache.filterIdentifiers(AZURE_INSTANCES.ns, Keys.getInstanceKey(AzureCloudProvider.ID, "*", "*", region, accountName))
     def instanceCacheResults = providerCache.getAll((AZURE_INSTANCES.ns), instanceIdentifiers, RelationshipCacheFilter.none())


### PR DESCRIPTION
Server Groups in Azure Cache are typed as `AUTHORITATIVE`. 

With the help of `claude`, it appears that if the type is `AUTHORITATIVE` the cache entries are manually evicted, However there is manual eviction code for server groups. I suspect having manual and automatic eviction occur on the same resource will cause problems in determining the actual state of the cloud environment.

This removes the manual eviction logic.

# references

Where automatic eviction is happening [here](https://github.com/spinnaker/spinnaker/blob/ffeaa35aa16f7e32fb1d62fd8d21edb13918e13a/clouddriver/clouddriver-api/src/main/java/com/netflix/spinnaker/cats/agent/CachingAgent.java#L90-L143) 