### PR TITLE
Enable boot diagnostics

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -79,6 +79,7 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
   Boolean useSystemManagedIdentity = false
   String userAssignedIdentities
   Boolean enableIpForwarding = false
+  String bootDiagnosticsStorageUri
 
   static class AzureScaleSetSku {
     String name

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/CreateAzureServerGroupAtomicOperation.groovy
@@ -200,6 +200,11 @@ class CreateAzureServerGroupAtomicOperation implements AtomicOperation<Map> {
         templateParameters[AzureServerGroupResourceTemplate.customDataParameterName] = description.osConfig.customData
       }
 
+      // Add boot diagnostics storage URI if provided
+      if(description.bootDiagnosticsStorageUri){
+        templateParameters[AzureServerGroupResourceTemplate.bootDiagnosticsStorageUriParameterName] = description.bootDiagnosticsStorageUri
+      }
+
       if (errList.isEmpty()) {
         description.subnetId = subnetId
         task.updateStatus(BASE_PHASE, "Deploying server group")

--- a/deck/packages/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
+++ b/deck/packages/azure/src/serverGroup/configure/serverGroupCommandBuilder.service.js
@@ -56,6 +56,7 @@ angular
               securityGroupsConfigured: false,
             },
             enableInboundNAT: false,
+            bootDiagnosticsStorageUri: '',
           };
         });
       }
@@ -120,6 +121,7 @@ angular
             disableStrategySelection: true,
           },
           enableInboundNAT: serverGroup.enableInboundNAT,
+          bootDiagnosticsStorageUri: serverGroup.bootDiagnosticsStorageUri || '',
         };
 
         if (typeof serverGroup.customScriptsSettings !== 'undefined') {

--- a/deck/packages/azure/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.html
+++ b/deck/packages/azure/src/serverGroup/configure/wizard/advancedSettings/advancedSettingsSelector.directive.html
@@ -24,6 +24,23 @@
       </div>
     </div>
     <div class="form-group">
+      <div class="col-xs-4 sm-label-right">
+        <b>Boot Diagnostics Storage URI</b>
+        <help-field key="azure.serverGroup.bootDiagnosticsStorageUri"></help-field>
+      </div>
+      <div class="col-md-7">
+        <input
+          type="text"
+          class="form-control input-sm"
+          ng-model="adv.command.bootDiagnosticsStorageUri"
+          placeholder="https://storageaccount.blob.core.windows.net/"
+        />
+        <small class="text-muted"
+          >Leave empty to disable boot diagnostics. Storage account must be in the same region.</small
+        >
+      </div>
+    </div>
+    <div class="form-group">
       <div class="col-md-4 sm-label-right">
         <b>Custom Script</b>
         <help-field key="azure.serverGroup.scriptLocation"></help-field>

--- a/deck/packages/azure/src/serverGroup/serverGroup.transformer.js
+++ b/deck/packages/azure/src/serverGroup/serverGroup.transformer.js
@@ -109,6 +109,7 @@ module(AZURE_SERVERGROUP_SERVERGROUP_TRANSFORMER, []).factory('azureServerGroupT
       zonesEnabled: command.zonesEnabled,
       zones: command.zonesEnabled ? command.zones : [],
       enableInboundNAT: command.enableInboundNAT,
+      bootDiagnosticsStorageUri: command.bootDiagnosticsStorageUri || '',
     };
 
     if (command.image == null || command.image.isCustom == false) {


### PR DESCRIPTION
# What?

enable boot diagnostics for Azure so we can start debugging instance start up.

# How?
- create a storage account in the same region as deployment.
- provide storage account uri to deployment
- boot diagnostics are now available

<img width="619" height="88" alt="Screenshot 2025-09-08 at 10 17 46 AM" src="https://github.com/user-attachments/assets/ab9f1a65-5c26-4102-b465-15e1e12687b4" />

