### PR TITLE
Update azure custom image cache refresh interval to 4 minutes

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/cache/AzureManagedImageCachingAgent.java
+++ b/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/cache/AzureManagedImageCachingAgent.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class AzureManagedImageCachingAgent
     implements CachingAgent, CustomScheduledAgent, AccountAware {
   private final Logger log = LoggerFactory.getLogger(getClass());
-  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.HOURS.toMillis(2);
+  private static final long DEFAULT_POLL_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(4);
   private static final long DEFAULT_TIMEOUT_MILLIS = TimeUnit.MINUTES.toMillis(30);
 
   private final AzureCloudProvider azureCloudProvider;

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageTagger.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageTagger.java
@@ -98,9 +98,6 @@ public class AzureImageTagger extends ImageTagger {
   protected boolean areImagesTagged(
       Collection<Image> targetImages, Collection<String> consideredStages, StageExecution stage) {
 
-    // returning true for now as appears force cache refresh is not working for images
-    // this can cause the pipeline to wait while the cache updates on its own schedule
-    /*
     for (Image targetImage : targetImages) {
       Map<String, String> additionalFilters = new HashMap<>();
       additionalFilters.put("managedImages", "true");
@@ -130,7 +127,6 @@ public class AzureImageTagger extends ImageTagger {
         }
       }
     }
-    */
 
     return true;
   }


### PR DESCRIPTION
# What?

- the cache refresh is not full implemented for any cloud provider.
- custom bake images take 2 hours for the cache to refresh.
- this changes it to 3 minutes. (in comparison AWS is 30 seconds)

Should fix timing with tagging the images.