### PR TITLE
Revert "Azure - remove manual server group cache evictions"

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -182,7 +182,6 @@ public class AzureComputeClient extends AzureBaseClient {
       }
     } catch (Exception e) {
       log.error("getServerGroupsAll -> Unexpected exception: ${e.message}")
-      throw new RuntimeException("Failed to fetch server groups from Azure API for region: ${region}", e)
     }
 
     serverGroups

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -103,6 +103,21 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
   }
 
   CacheResult removeDeadCacheEntries(CacheResult cacheResult, ProviderCache providerCache) {
+    // Server Groups
+    def sgIdentifiers = providerCache.filterIdentifiers(AZURE_SERVER_GROUPS.ns, Keys.getServerGroupKey(AzureCloudProvider.ID, "*", region, accountName))
+    def sgCacheResults = providerCache.getAll((AZURE_SERVER_GROUPS.ns), sgIdentifiers, RelationshipCacheFilter.none())
+    def evictedSGList = sgCacheResults.collect{ cached ->
+      if (!cacheResult.cacheResults[AZURE_SERVER_GROUPS.ns].find {it.id == cached.id}) {
+        cached.id
+      } else {
+        null
+      }
+    }
+    evictedSGList.removeAll(Collections.singleton(null))
+    if (evictedSGList) {
+      cacheResult.evictions[AZURE_SERVER_GROUPS.ns] = evictedSGList
+    }
+
     // Instances
     def instanceIdentifiers = providerCache.filterIdentifiers(AZURE_INSTANCES.ns, Keys.getInstanceKey(AzureCloudProvider.ID, "*", "*", region, accountName))
     def instanceCacheResults = providerCache.getAll((AZURE_INSTANCES.ns), instanceIdentifiers, RelationshipCacheFilter.none())


### PR DESCRIPTION
- Reverts moderneinc/spinnaker#17

Turns out is needed because manual eviction is need to handle deletes as it appears thats without this code the deletes will remain in cache. 