### PR TITLE
Fix image tagger

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/image/UpsertImageTagsStage.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/pipeline/image/UpsertImageTagsStage.java
@@ -34,7 +34,6 @@ public class UpsertImageTagsStage implements StageDefinitionBuilder {
   @Override
   public void taskGraph(@Nonnull StageExecution stage, @Nonnull TaskNode.Builder builder) {
     builder
-        .withTask("forceCacheRefresh", ImageForceCacheRefreshTask.class)
         .withTask("upsertImageTags", UpsertImageTagsTask.class)
         .withTask("monitorUpsert", MonitorKatoTask.class)
         .withTask("forceCacheRefresh", ImageForceCacheRefreshTask.class)

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageTagger.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageTagger.java
@@ -232,39 +232,8 @@ public class AzureImageTagger extends ImageTagger {
   @Override
   protected boolean areImagesTagged(
       Collection<Image> targetImages, Collection<String> consideredStages, StageExecution stage) {
-
-    for (Image targetImage : targetImages) {
-      Map<String, String> additionalFilters = new HashMap<>();
-      additionalFilters.put("managedImages", "true");
-      additionalFilters.put("galleryImages", "true");
-
-      List<Map> foundImages =
-          Retrofit2SyncCall.execute(
-              oortService.findImage(
-                  getCloudProvider(),
-                  targetImage.imageName,
-                  targetImage.account,
-                  null,
-                  additionalFilters));
-
-      if (foundImages.isEmpty()) {
-        return false;
-      }
-
-      Map foundImage = foundImages.get(0);
-      Map<String, String> imageTags = (Map<String, String>) foundImage.get("tags");
-
-      if (imageTags == null) {
-        return false;
-      }
-
-      for (Map.Entry<String, String> targetTag : targetImage.tags.entrySet()) {
-        if (!targetTag.getValue().equals(imageTags.get(targetTag.getKey()))) {
-          return false;
-        }
-      }
-    }
-
+    // Skip cache verification — tagging is confirmed via monitorUpsert (Kato task).
+    // The image cache refresh lag causes this check to time out for newly baked images.
     return true;
   }
 


### PR DESCRIPTION
# What?

removing  the additional `forceCacheRefresh`, currently a no-op and should not cause any problems.

`areImagesTagged` is redundant since `monitorUpsert` already confirms the tagging operation succeeded via the Kato task, this cache verification is both redundant and broken for gallery images with multiple versions.