### PR TITLE
reduce redundant Azure API calls and increase retry resilience

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
@@ -40,7 +40,7 @@ import java.time.Duration
 @CompileStatic
 abstract class AzureBaseClient {
   final String subscriptionId
-  final static long AZURE_ATOMICOPERATION_RETRY = 5
+  final static long AZURE_ATOMICOPERATION_RETRY = 15
   final static int HTTP_TOO_MANY_REQUESTS = 429
   final static int DEFAULT_429_RETRY_INTERVAL_SEC = 30
   final static int MAX_429_RETRY_INTERVAL_SEC = 120
@@ -69,7 +69,7 @@ abstract class AzureBaseClient {
     ).build()
 
     def retryPolicy = new RetryPolicy(
-      new ExponentialBackoff(5, Duration.ofSeconds(2), Duration.ofSeconds(60))
+      new ExponentialBackoff(8, Duration.ofSeconds(5), Duration.ofSeconds(120))
     )
 
     AzureResourceManager

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -318,20 +318,16 @@ public class AzureComputeClient extends AzureBaseClient {
    * check the scale set's health status, wait for the timeout return true when healthy, false if we hit the timeout
    */
   Boolean waitForScaleSetHealthy(String resourceGroupName, String serverGroupName, long timeoutMillis) {
-    def now = System.nanoTime()
-    def currentTime = System.nanoTime()
+    def startNanos = System.nanoTime()
+    def timeoutNanos = timeoutMillis * 1_000_000
 
-    // TODO: use available health probes to determine the sleep time
-    def sleepTimeSeconds = 5
-
-    while (currentTime - now < timeoutMillis * 1000000) {
+    while (System.nanoTime() - startNanos < timeoutNanos) {
       def instances = getServerGroupInstances(resourceGroupName, serverGroupName)
-      if (!instances.any { it.healthState != HealthState.Up }) {
+      if (instances.every { it.healthState == HealthState.Up }) {
         return true
       }
 
-      Thread.sleep(sleepTimeSeconds * 1000)
-      currentTime = System.nanoTime()
+      Thread.sleep(30 * 1000)
     }
 
     false

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DisableAzureServerGroupAtomicOperation.groovy
@@ -49,7 +49,7 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
     def region = description.region
     if (description.serverGroupName) description.name = description.serverGroupName
     if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
-    task.updateStatus BASE_PHASE, "Disablinging server group ${description.name} " + "in ${region}..."
+    task.updateStatus BASE_PHASE, "Disabling server group ${description.name} in ${region}..."
 
     if (!description.credentials) {
       throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
@@ -98,10 +98,7 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   private void disableServerGroupWithoutLoadBalancers(String resourceGroupName, AzureServerGroupDescription serverGroupDescription, region) {
-    if (description
-      .credentials
-      .networkClient
-      .isServerGroupWithoutLoadBalancerDisabled(resourceGroupName, serverGroupDescription.name)) {
+    if (serverGroupDescription.disabled) {
       task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already disabled."
     } else {
       // there is no concept of a "disabled" server group without a load balancer, so scale to 0
@@ -115,10 +112,10 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   private void disableServerGroupWithApplicationGateway(String resourceGroupName, AzureServerGroupDescription serverGroupDescription, region) {
-    String loadBalancerRG = serverGroupDescription.loadBalancerResourceGroup ?: resourceGroupName
-    if (description.credentials.networkClient.isServerGroupWithAppGatewayDisabled(resourceGroupName, loadBalancerRG, serverGroupDescription.appGatewayName, serverGroupDescription.name, serverGroupDescription.backendPoolName)) {
+    if (serverGroupDescription.disabled) {
       task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already disabled."
     } else {
+      String loadBalancerRG = serverGroupDescription.loadBalancerResourceGroup ?: resourceGroupName
       description
         .credentials
         .networkClient
@@ -129,7 +126,7 @@ class DisableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   private void disableServerGroupWithLoadBalancer(String resourceGroupName, AzureServerGroupDescription serverGroupDescription, region) {
-    if (description.credentials.networkClient.isServerGroupWithLoadBalancerDisabled(resourceGroupName, serverGroupDescription.loadBalancerName, serverGroupDescription.name, serverGroupDescription.backendPoolName)) {
+    if (serverGroupDescription.disabled) {
       task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already disabled."
     } else {
       description

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/EnableAzureServerGroupAtomicOperation.groovy
@@ -49,7 +49,7 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
     def region = description.region
     if (description.serverGroupName) description.name = description.serverGroupName
     if (!description.application) description.application = description.appName ?: Names.parseName(description.name).app
-    task.updateStatus BASE_PHASE, "Enabling server group ${description.name} " + "in ${region}..."
+    task.updateStatus BASE_PHASE, "Enabling server group ${description.name} in ${region}..."
 
     if (!description.credentials) {
       throw new IllegalArgumentException("Unable to resolve credentials for the selected Azure account.")
@@ -66,29 +66,23 @@ class EnableAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
         errList.add("could not find server group ${description.name} in ${region}")
       } else {
         try {
-          if (serverGroupDescription.loadBalancerType == AzureLoadBalancer.AzureLoadBalancerType.AZURE_LOAD_BALANCER.toString()) {
-            if (description.credentials.networkClient.isServerGroupWithLoadBalancerDisabled(resourceGroupName, serverGroupDescription.loadBalancerName, serverGroupDescription.name, serverGroupDescription.backendPoolName)) {
-              description
-                .credentials
-                .networkClient
-                .enableServerGroupWithLoadBalancer(resourceGroupName, serverGroupDescription.loadBalancerName, serverGroupDescription.name, serverGroupDescription.backendPoolName)
+          if (!serverGroupDescription.disabled) {
+            task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already enabled."
+          } else if (serverGroupDescription.loadBalancerType == AzureLoadBalancer.AzureLoadBalancerType.AZURE_LOAD_BALANCER.toString()) {
+            description
+              .credentials
+              .networkClient
+              .enableServerGroupWithLoadBalancer(resourceGroupName, serverGroupDescription.loadBalancerName, serverGroupDescription.name, serverGroupDescription.backendPoolName)
 
-              waitForHealthy(resourceGroupName, serverGroupDescription, region, errList)
-            } else {
-              task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already enabled."
-            }
+            waitForHealthy(resourceGroupName, serverGroupDescription, region, errList)
           } else if (serverGroupDescription.loadBalancerType == AzureLoadBalancer.AzureLoadBalancerType.AZURE_APPLICATION_GATEWAY.toString()) {
             String loadBalancerRG = serverGroupDescription.loadBalancerResourceGroup ?: resourceGroupName
-            if (description.credentials.networkClient.isServerGroupWithAppGatewayDisabled(resourceGroupName, loadBalancerRG, serverGroupDescription.appGatewayName, serverGroupDescription.name, serverGroupDescription.backendPoolName)) {
-              description
-                .credentials
-                .networkClient
-                .enableServerGroupWithAppGateway(resourceGroupName, loadBalancerRG, serverGroupDescription.appGatewayName, serverGroupDescription.name, serverGroupDescription.backendPoolName)
+            description
+              .credentials
+              .networkClient
+              .enableServerGroupWithAppGateway(resourceGroupName, loadBalancerRG, serverGroupDescription.appGatewayName, serverGroupDescription.name, serverGroupDescription.backendPoolName)
 
-              waitForHealthy(resourceGroupName, serverGroupDescription, region, errList)
-            } else {
-              task.updateStatus BASE_PHASE, "Azure server group ${serverGroupDescription.name} in ${region} is already enabled."
-            }
+            waitForHealthy(resourceGroupName, serverGroupDescription, region, errList)
           } else {
             throw new RuntimeException("Azure server group with load balancer type $serverGroupDescription.loadBalancerType cannot be enabled.")
           }


### PR DESCRIPTION
- Compute VMSS disabled state from inner model data during build() instead of making separate API calls
- Eliminate redundant VMSS fetches in disable/enable operations (was fetching the same VMSS 2-3 times per operation)
- Remove per-server-group disabled-state API calls from the caching agent
- Increase health polling interval from 5s to 30s
- Increase SDK retry policy (5→8 retries, longer backoff) and operation retry count (5→15)