### PR TITLE
register AzureGalleryImageCachingAgent

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsLifecycleHandler.java
+++ b/clouddriver/clouddriver-azure/src/main/java/com/netflix/spinnaker/clouddriver/azure/security/AzureCredentialsLifecycleHandler.java
@@ -27,6 +27,7 @@ import com.netflix.spinnaker.clouddriver.azure.resources.securitygroup.cache.Azu
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.cache.AzureServerGroupCachingAgent;
 import com.netflix.spinnaker.clouddriver.azure.resources.subnet.cache.AzureSubnetCachingAgent;
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureCustomImageCachingAgent;
+import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureGalleryImageCachingAgent;
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureManagedImageCachingAgent;
 import com.netflix.spinnaker.clouddriver.azure.resources.vmimage.cache.AzureVMImageCachingAgent;
 import com.netflix.spinnaker.clouddriver.security.AccountCredentialsProvider;
@@ -114,6 +115,10 @@ public class AzureCredentialsLifecycleHandler
 
               agents.add(
                   new AzureManagedImageCachingAgent(
+                      azureCloudProvider, accountName, creds, regionName, objectMapper));
+
+              agents.add(
+                  new AzureGalleryImageCachingAgent(
                       azureCloudProvider, accountName, creds, regionName, objectMapper));
             });
 


### PR DESCRIPTION
#What?

FindImageFromTagsTask was failing Azure deploys with "Could not find tagged image" whenever the base image lived in a Shared Image Gallery, the `AZURE_GALLERYIMAGES` cache was always empty.

Root cause: AzureGalleryImageCachingAgent was never registered. AzureCredentialsLifecycleHandler (the active agent registration path) wires up every other Azure caching agent but omits the gallery one, so it never ran.