### PR TITLE
resolve docker/image:latest to peer semver tag during artifact resolution

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
@@ -17,9 +17,11 @@
 package com.netflix.spinnaker.clouddriver.ecs.controllers;
 
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsDockerImage;
+import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcrDockerTagResolver;
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.ImageRepositoryProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,10 +33,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/ecs/images")
 public class EcsImagesController {
   private final List<ImageRepositoryProvider> imageRepositoryProviders;
+  private final EcrDockerTagResolver ecrDockerTagResolver;
 
   @Autowired
-  public EcsImagesController(List<ImageRepositoryProvider> imageRepositoryProviders) {
+  public EcsImagesController(
+      List<ImageRepositoryProvider> imageRepositoryProviders,
+      EcrDockerTagResolver ecrDockerTagResolver) {
     this.imageRepositoryProviders = imageRepositoryProviders;
+    this.ecrDockerTagResolver = ecrDockerTagResolver;
   }
 
   @RequestMapping(value = "/find", method = RequestMethod.GET)
@@ -52,5 +58,11 @@ public class EcsImagesController {
                 .map(ImageRepositoryProvider::getRepositoryName)
                 .collect(Collectors.joining(", "))
             + ".");
+  }
+
+  @RequestMapping(value = "/resolveDockerTag", method = RequestMethod.GET)
+  public Map<String, String> resolveDockerTag(@RequestParam("reference") String reference) {
+    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolve(reference);
+    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
   }
 }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.view;
+
+import com.amazonaws.services.ecr.AmazonECR;
+import com.amazonaws.services.ecr.model.DescribeImagesRequest;
+import com.amazonaws.services.ecr.model.DescribeImagesResult;
+import com.amazonaws.services.ecr.model.ImageDetail;
+import com.amazonaws.services.ecr.model.ImageIdentifier;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Given a fully-qualified ECR image reference whose tag is a moving alias (e.g. {@code latest}),
+ * looks up the underlying image digest and returns the highest stable semver tag that shares that
+ * digest. "Stable semver" here matches {@code N.N.N} (no pre-release suffix), which lines up with
+ * the format that jib publishes for non-SNAPSHOT releases.
+ *
+ * <p>Throws on no peer match (caller must not silently fall through; that reintroduces the bug
+ * this class exists to fix).
+ */
+@Component
+public class EcrDockerTagResolver {
+  private static final Pattern STABLE_SEMVER = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
+
+  private final AmazonClientProvider amazonClientProvider;
+  private final CredentialsRepository<NetflixECSCredentials> credentialsRepository;
+
+  @Autowired
+  public EcrDockerTagResolver(
+      AmazonClientProvider amazonClientProvider,
+      CredentialsRepository<NetflixECSCredentials> credentialsRepository) {
+    this.amazonClientProvider = amazonClientProvider;
+    this.credentialsRepository = credentialsRepository;
+  }
+
+  public ResolveResult resolve(String reference) {
+    EcrReference parsed = EcrReference.parse(reference);
+    NetflixAmazonCredentials credentials = lookupCredentials(parsed.accountId, parsed.region);
+    if (!isValidRegion(credentials, parsed.region)) {
+      throw new IllegalArgumentException(
+          "ECR reference "
+              + reference
+              + " uses region "
+              + parsed.region
+              + " which is not enabled on the matched credentials.");
+    }
+
+    AmazonECR ecr = amazonClientProvider.getAmazonEcr(credentials, parsed.region, false);
+
+    DescribeImagesResult byTag =
+        ecr.describeImages(
+            new DescribeImagesRequest()
+                .withRegistryId(parsed.accountId)
+                .withRepositoryName(parsed.repository)
+                .withImageIds(new ImageIdentifier().withImageTag(parsed.tag)));
+
+    if (byTag.getImageDetails() == null || byTag.getImageDetails().isEmpty()) {
+      throw new NotFoundException(
+          "No ECR image found for tag " + parsed.tag + " in repository " + parsed.repository);
+    }
+
+    ImageDetail detail = byTag.getImageDetails().get(0);
+    String digest = detail.getImageDigest();
+    List<String> peerTags =
+        Optional.ofNullable(detail.getImageTags()).orElseGet(java.util.Collections::emptyList);
+
+    Optional<String> resolved =
+        peerTags.stream()
+            .filter(t -> !parsed.tag.equals(t))
+            .filter(t -> STABLE_SEMVER.matcher(t).matches())
+            .max(EcrDockerTagResolver::compareSemver);
+
+    if (resolved.isPresent()) {
+      return new ResolveResult(resolved.get(), rewriteReference(reference, parsed.tag, resolved.get()));
+    }
+
+    throw new NotFoundException(
+        "ECR image "
+            + reference
+            + " (digest "
+            + digest
+            + ") has no peer tag matching stable semver "
+            + STABLE_SEMVER.pattern()
+            + "; peer tags were "
+            + peerTags);
+  }
+
+  private NetflixAmazonCredentials lookupCredentials(String accountId, String region) {
+    for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
+      if (credentials.getAccountId().equals(accountId)
+          && (credentials.getRegions().isEmpty()
+              || credentials.getRegions().stream()
+                  .anyMatch(r -> r.getName().equals(region)))) {
+        return credentials;
+      }
+    }
+    throw new NotFoundException(
+        "No AWS credentials match ECR account " + accountId + " in region " + region);
+  }
+
+  private static boolean isValidRegion(NetflixAmazonCredentials credentials, String region) {
+    return credentials.getRegions().stream()
+        .map(AmazonCredentials.AWSRegion::getName)
+        .anyMatch(region::equals);
+  }
+
+  private static String rewriteReference(String reference, String oldTag, String newTag) {
+    int colon = reference.lastIndexOf(':' + oldTag);
+    if (colon < 0) {
+      return reference + ":" + newTag;
+    }
+    return reference.substring(0, colon) + ":" + newTag;
+  }
+
+  static int compareSemver(String left, String right) {
+    String[] leftParts = left.split("\\.");
+    String[] rightParts = right.split("\\.");
+    int len = Math.min(leftParts.length, rightParts.length);
+    for (int i = 0; i < len; i++) {
+      int cmp = Integer.compare(Integer.parseInt(leftParts[i]), Integer.parseInt(rightParts[i]));
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    return Integer.compare(leftParts.length, rightParts.length);
+  }
+
+  public static final class ResolveResult {
+    public final String resolvedTag;
+    public final String resolvedReference;
+
+    ResolveResult(String resolvedTag, String resolvedReference) {
+      this.resolvedTag = resolvedTag;
+      this.resolvedReference = resolvedReference;
+    }
+  }
+
+  static final class EcrReference {
+    final String accountId;
+    final String region;
+    final String repository;
+    final String tag;
+
+    private EcrReference(String accountId, String region, String repository, String tag) {
+      this.accountId = accountId;
+      this.region = region;
+      this.repository = repository;
+      this.tag = tag;
+    }
+
+    private static final Pattern PATTERN =
+        Pattern.compile(
+            "^(?:https?://)?(\\d{12})\\.dkr\\.ecr\\.([a-z0-9-]+)\\.amazonaws\\.com/([^:]+):(.+)$");
+
+    static EcrReference parse(String reference) {
+      Matcher m = PATTERN.matcher(reference);
+      if (!m.matches()) {
+        throw new IllegalArgumentException(
+            "Reference is not a valid tagged ECR URI: " + reference);
+      }
+      return new EcrReference(m.group(1), m.group(2), m.group(3), m.group(4));
+    }
+  }
+}

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.ecs.provider.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.amazonaws.services.ecr.AmazonECR;
+import com.amazonaws.services.ecr.model.DescribeImagesRequest;
+import com.amazonaws.services.ecr.model.DescribeImagesResult;
+import com.amazonaws.services.ecr.model.ImageDetail;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
+import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
+import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
+import com.netflix.spinnaker.credentials.CredentialsRepository;
+import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+
+final class EcrDockerTagResolverTest {
+
+  private AmazonClientProvider amazonClientProvider;
+  private CredentialsRepository<NetflixECSCredentials> credentialsRepository;
+  private AmazonECR ecr;
+  private EcrDockerTagResolver target;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  void setUp() {
+    amazonClientProvider = org.mockito.Mockito.mock(AmazonClientProvider.class);
+    credentialsRepository = org.mockito.Mockito.mock(CredentialsRepository.class);
+    ecr = org.mockito.Mockito.mock(AmazonECR.class);
+
+    NetflixECSCredentials creds = stubCredentials("297794628946", "us-west-2");
+    org.mockito.Mockito.when(credentialsRepository.getAll()).thenReturn(Set.of(creds));
+    org.mockito.Mockito.when(
+            amazonClientProvider.getAmazonEcr(
+                ArgumentMatchers.any(), ArgumentMatchers.eq("us-west-2"), ArgumentMatchers.eq(false)))
+        .thenReturn(ecr);
+
+    target = new EcrDockerTagResolver(amazonClientProvider, credentialsRepository);
+  }
+
+  @Test
+  void picksHighestStableSemverFromPeerTags() {
+    stubDescribeImages(List.of("latest", "0.147.3", "0.146.0", "0.147.3-rc1"));
+    EcrDockerTagResolver.ResolveResult result =
+        target.resolve(
+            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+    assertThat(result.resolvedTag).isEqualTo("0.147.3");
+    assertThat(result.resolvedReference)
+        .isEqualTo(
+            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3");
+  }
+
+  @Test
+  void excludesPreReleaseTagsEvenWhenSolePeer() {
+    stubDescribeImages(List.of("latest", "0.147.3-rc1", "0.147.3-SNAPSHOT-20260427-181523"));
+    assertThatThrownBy(
+            () ->
+                target.resolve(
+                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("no peer tag matching stable semver");
+  }
+
+  @Test
+  void onlyLatestTag_throws() {
+    stubDescribeImages(List.of("latest"));
+    assertThatThrownBy(
+            () ->
+                target.resolve(
+                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+        .isInstanceOf(NotFoundException.class);
+  }
+
+  @Test
+  void noImageForTag_throws() {
+    org.mockito.Mockito.when(ecr.describeImages(ArgumentMatchers.any(DescribeImagesRequest.class)))
+        .thenReturn(new DescribeImagesResult());
+    assertThatThrownBy(
+            () ->
+                target.resolve(
+                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("No ECR image found for tag latest");
+  }
+
+  @Test
+  void compareSemverNumerically() {
+    // Ensure 0.10.0 > 0.9.9 (numeric, not lexicographic)
+    stubDescribeImages(List.of("latest", "0.9.9", "0.10.0"));
+    EcrDockerTagResolver.ResolveResult result =
+        target.resolve(
+            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+    assertThat(result.resolvedTag).isEqualTo("0.10.0");
+  }
+
+  @Test
+  void invalidEcrReference_throws() {
+    assertThatThrownBy(() -> target.resolve("docker.io/library/nginx:latest"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a valid tagged ECR URI");
+  }
+
+  @Test
+  void parsesReferenceComponents() {
+    EcrDockerTagResolver.EcrReference parsed =
+        EcrDockerTagResolver.EcrReference.parse(
+            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+    assertThat(parsed.accountId).isEqualTo("297794628946");
+    assertThat(parsed.region).isEqualTo("us-west-2");
+    assertThat(parsed.repository).isEqualTo("moderne/recipe-worker-arm64");
+    assertThat(parsed.tag).isEqualTo("latest");
+  }
+
+  private void stubDescribeImages(List<String> tags) {
+    DescribeImagesResult describe =
+        new DescribeImagesResult()
+            .withImageDetails(
+                new ImageDetail()
+                    .withImageDigest("sha256:abc123")
+                    .withImageTags(tags));
+    org.mockito.Mockito.when(ecr.describeImages(ArgumentMatchers.any(DescribeImagesRequest.class)))
+        .thenReturn(describe);
+  }
+
+  private static NetflixECSCredentials stubCredentials(String accountId, String region) {
+    NetflixECSCredentials credentials = org.mockito.Mockito.mock(NetflixECSCredentials.class);
+    org.mockito.Mockito.when(credentials.getAccountId()).thenReturn(accountId);
+    AmazonCredentials.AWSRegion awsRegion = org.mockito.Mockito.mock(AmazonCredentials.AWSRegion.class);
+    org.mockito.Mockito.when(awsRegion.getName()).thenReturn(region);
+    org.mockito.Mockito.when(credentials.getRegions()).thenReturn(List.of(awsRegion));
+    return (NetflixECSCredentials) credentials;
+  }
+}

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -166,6 +166,11 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public Call<Map<String, String>> resolveDockerTag(String reference) {
+    return getService().resolveDockerTag(reference);
+  }
+
+  @Override
   public Call<List<Map<String, Object>>> getEntityTags(
       String cloudProvider, String entityType, String entityId, String account, String region) {
     return getService().getEntityTags(cloudProvider, entityType, entityId, account, region);

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import com.netflix.spinnaker.orca.pipeline.util.DockerLatestResolver;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Resolves docker/image artifacts whose reference points at an ECR registry by delegating to
+ * clouddriver's {@code /ecs/images/resolveDockerTag} endpoint, which performs the digest→tag
+ * lookup using the existing AWS credentials repository.
+ */
+@Component
+public class EcrDockerLatestResolver implements DockerLatestResolver {
+  private static final Pattern ECR_REFERENCE =
+      Pattern.compile(
+          "^(?:https?://)?\\d{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/.+:.+$");
+
+  private final OortService oortService;
+
+  @Autowired
+  public EcrDockerLatestResolver(OortService oortService) {
+    this.oortService = oortService;
+  }
+
+  @Override
+  public boolean handles(Artifact artifact) {
+    String reference = artifact.getReference();
+    return reference != null && ECR_REFERENCE.matcher(reference).matches();
+  }
+
+  @Override
+  public Artifact canonicalize(Artifact artifact) {
+    Map<String, String> response =
+        Retrofit2SyncCall.execute(oortService.resolveDockerTag(artifact.getReference()));
+    String resolvedTag = response.get("resolvedTag");
+    String resolvedReference = response.get("reference");
+    if (resolvedTag == null || resolvedReference == null) {
+      throw new IllegalStateException(
+          "clouddriver resolveDockerTag returned an incomplete response: " + response);
+    }
+    return artifact.toBuilder().version(resolvedTag).reference(resolvedReference).build();
+  }
+}

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -166,6 +166,15 @@ public interface OortService {
       @Query("region") String region,
       @QueryMap Map<String, String> additionalFilters);
 
+  /**
+   * Resolves a docker image reference whose tag is a moving alias (e.g. {@code latest}) to its
+   * canonical pinned semver tag in ECR. The {@code reference} parameter is the full image URI,
+   * including the registry, repository, and current tag. The response carries the resolved tag and
+   * a fully-qualified reference with that tag substituted in.
+   */
+  @GET("ecs/images/resolveDockerTag")
+  Call<Map<String, String>> resolveDockerTag(@Query("reference") String reference);
+
   @GET("tags")
   Call<List<Map<String, Object>>> getEntityTags(
       @Query("cloudProvider") String cloudProvider,

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/FindArtifactFromExecutionTask.java
@@ -26,20 +26,34 @@ import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus;
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import com.netflix.spinnaker.orca.pipeline.util.DockerLatestResolutionService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nonnull;
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 @Component
-@RequiredArgsConstructor
 public class FindArtifactFromExecutionTask implements Task {
   public static final String TASK_NAME = "findArtifactFromExecution";
 
   private final ArtifactUtils artifactUtils;
+  private final DockerLatestResolutionService dockerLatestResolutionService;
+
+  @Autowired
+  public FindArtifactFromExecutionTask(
+      ArtifactUtils artifactUtils,
+      DockerLatestResolutionService dockerLatestResolutionService) {
+    this.artifactUtils = artifactUtils;
+    this.dockerLatestResolutionService = dockerLatestResolutionService;
+  }
+
+  /** Convenience constructor for tests/legacy callers; uses a no-op resolution service. */
+  public FindArtifactFromExecutionTask(ArtifactUtils artifactUtils) {
+    this(artifactUtils, new DockerLatestResolutionService(null));
+  }
 
   @Nonnull
   @Override
@@ -68,6 +82,7 @@ public class FindArtifactFromExecutionTask implements Task {
     ArtifactResolver.ResolveResult resolveResult =
         ArtifactResolver.getInstance(priorArtifacts, /* requireUniqueMatches= */ false)
             .resolveExpectedArtifacts(expectedArtifacts);
+    resolveResult = dockerLatestResolutionService.canonicalize(resolveResult);
 
     outputs.put("resolvedExpectedArtifacts", resolveResult.getResolvedExpectedArtifacts());
     outputs.put("artifacts", resolveResult.getResolvedArtifacts());

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import java.util.Map;
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import retrofit2.Call;
+import retrofit2.Response;
+import retrofit2.mock.Calls;
+
+final class EcrDockerLatestResolverTest {
+
+  private static final String LATEST_REF =
+      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
+  private static final String RESOLVED_REF =
+      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
+
+  private OortService oortService;
+  private EcrDockerLatestResolver target;
+
+  @BeforeEach
+  void setUp() {
+    oortService = mock(OortService.class);
+    target = new EcrDockerLatestResolver(oortService);
+  }
+
+  @Test
+  void handles_ecrReference() {
+    Artifact ecr =
+        Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+    assertThat(target.handles(ecr)).isTrue();
+  }
+
+  @Test
+  void doesNotHandle_dockerHubReference() {
+    Artifact dockerHub =
+        Artifact.builder().type("docker/image").reference("docker.io/library/nginx:latest").build();
+    assertThat(target.handles(dockerHub)).isFalse();
+  }
+
+  @Test
+  void doesNotHandle_nullReference() {
+    Artifact noRef = Artifact.builder().type("docker/image").build();
+    assertThat(target.handles(noRef)).isFalse();
+  }
+
+  @Test
+  void canonicalize_callsOortServiceAndRewritesArtifact() {
+    Call<Map<String, String>> call =
+        Calls.response(Map.of("resolvedTag", "0.147.3", "reference", RESOLVED_REF));
+    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+
+    Artifact input =
+        Artifact.builder()
+            .type("docker/image")
+            .name("moderne/recipe-worker-arm64")
+            .version("latest")
+            .reference(LATEST_REF)
+            .build();
+    Artifact result = target.canonicalize(input);
+    assertThat(result.getVersion()).isEqualTo("0.147.3");
+    assertThat(result.getReference()).isEqualTo(RESOLVED_REF);
+    assertThat(result.getName()).isEqualTo("moderne/recipe-worker-arm64");
+  }
+
+  @Test
+  void canonicalize_oortReturnsIncompleteResponse_throws() {
+    Call<Map<String, String>> call = Calls.response(Map.of("resolvedTag", "0.147.3"));
+    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+
+    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+    assertThatThrownBy(() -> target.canonicalize(input))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("incomplete response");
+  }
+
+  @Test
+  void canonicalize_oortPropagatesErrorAsRuntime() {
+    Call<Map<String, String>> call =
+        Calls.response(
+            Response.error(
+                404,
+                ResponseBody.create("not found", MediaType.parse("text/plain"))));
+    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+
+    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+    assertThatThrownBy(() -> target.canonicalize(input)).isInstanceOf(RuntimeException.class);
+  }
+}

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/artifacts/BindProducedArtifactsTask.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/tasks/artifacts/BindProducedArtifactsTask.java
@@ -29,6 +29,7 @@ import com.netflix.spinnaker.orca.config.TaskConfigurationProperties;
 import com.netflix.spinnaker.orca.config.TaskConfigurationProperties.BindProducedArtifactsTaskConfig;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactResolver;
 import com.netflix.spinnaker.orca.pipeline.util.ArtifactUtils;
+import com.netflix.spinnaker.orca.pipeline.util.DockerLatestResolutionService;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,16 +45,27 @@ public class BindProducedArtifactsTask implements Task {
   private final ArtifactUtils artifactUtils;
   private final ObjectMapper objectMapper;
   private final BindProducedArtifactsTaskConfig configProperties;
+  private final DockerLatestResolutionService dockerLatestResolutionService;
 
   @Autowired
   public BindProducedArtifactsTask(
       ArtifactUtils artifactUtils,
       ObjectMapper objectMapper,
-      TaskConfigurationProperties configProperties) {
+      TaskConfigurationProperties configProperties,
+      DockerLatestResolutionService dockerLatestResolutionService) {
     this.artifactUtils = artifactUtils;
     this.objectMapper = objectMapper;
     this.configProperties = configProperties.getBindProducedArtifactsTask();
+    this.dockerLatestResolutionService = dockerLatestResolutionService;
     log.info("output keys to filter: {}", this.configProperties.getExcludeKeysFromOutputs());
+  }
+
+  /** Convenience constructor for tests and legacy callers; uses a no-op resolution service. */
+  public BindProducedArtifactsTask(
+      ArtifactUtils artifactUtils,
+      ObjectMapper objectMapper,
+      TaskConfigurationProperties configProperties) {
+    this(artifactUtils, objectMapper, configProperties, new DockerLatestResolutionService(null));
   }
 
   @Nonnull
@@ -74,6 +86,7 @@ public class BindProducedArtifactsTask implements Task {
     ArtifactResolver.ResolveResult resolveResult =
         ArtifactResolver.getInstance(artifacts, /* requireUniqueMatches= */ false)
             .resolveExpectedArtifacts(expectedArtifacts);
+    resolveResult = dockerLatestResolutionService.canonicalize(resolveResult);
 
     outputs.put("artifacts", resolveResult.getResolvedArtifacts());
     outputs.put("resolvedExpectedArtifacts", resolveResult.getResolvedExpectedArtifacts());

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactResolver.java
@@ -185,5 +185,11 @@ public final class ArtifactResolver {
      * to the artifact that it matched during resolution.
      */
     private final ImmutableList<ExpectedArtifact> resolvedExpectedArtifacts;
+
+    public static ResolveResult create(
+        ImmutableList<Artifact> resolvedArtifacts,
+        ImmutableList<ExpectedArtifact> resolvedExpectedArtifacts) {
+      return new ResolveResult(resolvedArtifacts, resolvedExpectedArtifacts);
+    }
   }
 }

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/ArtifactUtils.java
@@ -64,15 +64,34 @@ public class ArtifactUtils {
   private final ObjectMapper objectMapper;
   private final ExecutionRepository executionRepository;
   private final ContextParameterProcessor contextParameterProcessor;
+  private final DockerLatestResolutionService dockerLatestResolutionService;
 
   @Autowired
   public ArtifactUtils(
       ObjectMapper objectMapper,
       ExecutionRepository executionRepository,
-      ContextParameterProcessor contextParameterProcessor) {
+      ContextParameterProcessor contextParameterProcessor,
+      DockerLatestResolutionService dockerLatestResolutionService) {
     this.objectMapper = objectMapper;
     this.executionRepository = executionRepository;
     this.contextParameterProcessor = contextParameterProcessor;
+    this.dockerLatestResolutionService = dockerLatestResolutionService;
+  }
+
+  /**
+   * Convenience constructor for tests and legacy callers; uses a no-op {@link
+   * DockerLatestResolutionService} (no resolvers registered, so docker/image:latest artifacts
+   * pass through unchanged).
+   */
+  public ArtifactUtils(
+      ObjectMapper objectMapper,
+      ExecutionRepository executionRepository,
+      ContextParameterProcessor contextParameterProcessor) {
+    this(
+        objectMapper,
+        executionRepository,
+        contextParameterProcessor,
+        new DockerLatestResolutionService(null));
   }
 
   public List<Artifact> getArtifacts(StageExecution stage) {
@@ -234,6 +253,7 @@ public class ArtifactUtils {
                 () -> getPriorArtifacts(pipeline),
                 /* requireUniqueMatches= */ true)
             .resolveExpectedArtifacts(expectedArtifacts);
+    resolveResult = dockerLatestResolutionService.canonicalize(resolveResult);
 
     ImmutableSet<Artifact> allArtifacts =
         ImmutableSet.<Artifact>builder()

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionService.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionService.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+/**
+ * Post-processes resolved artifacts to replace {@code docker/image:latest} (and any other moving
+ * tag aliases) with their canonical pinned-version equivalent. Applied after {@link
+ * ArtifactResolver#resolveExpectedArtifacts} so matching against {@code matchArtifact} predicates
+ * still uses the original (pre-canonicalization) values, preserving backward compatibility for
+ * pipelines that match on a literal {@code latest} version.
+ *
+ * <p>If no registered {@link DockerLatestResolver} handles an artifact's reference, the artifact
+ * is left unchanged (defensive default — non-ECR registries or unrecognized providers are passed
+ * through rather than failing the resolution).
+ */
+@Component
+@Slf4j
+public class DockerLatestResolutionService {
+  private static final String DOCKER_IMAGE_TYPE = "docker/image";
+  private static final String LATEST = "latest";
+
+  private final List<DockerLatestResolver> resolvers;
+
+  @Autowired
+  public DockerLatestResolutionService(@Nullable List<DockerLatestResolver> resolvers) {
+    this.resolvers = resolvers != null ? resolvers : Collections.emptyList();
+  }
+
+  public Artifact canonicalize(@Nullable Artifact artifact) {
+    if (artifact == null || !needsCanonicalization(artifact)) {
+      return artifact;
+    }
+    for (DockerLatestResolver resolver : resolvers) {
+      if (resolver.handles(artifact)) {
+        Artifact canonical = resolver.canonicalize(artifact);
+        log.info(
+            "canonicalized docker artifact reference {} -> {} (version {} -> {})",
+            artifact.getReference(),
+            canonical.getReference(),
+            artifact.getVersion(),
+            canonical.getVersion());
+        return canonical;
+      }
+    }
+    log.debug(
+        "no DockerLatestResolver handled reference {}; passing through unchanged",
+        artifact.getReference());
+    return artifact;
+  }
+
+  public ArtifactResolver.ResolveResult canonicalize(ArtifactResolver.ResolveResult result) {
+    if (resolvers.isEmpty()) {
+      return result;
+    }
+    ImmutableList<Artifact> resolvedArtifacts =
+        result.getResolvedArtifacts().stream()
+            .map(this::canonicalize)
+            .collect(ImmutableList.toImmutableList());
+    ImmutableList<ExpectedArtifact> resolvedExpectedArtifacts =
+        result.getResolvedExpectedArtifacts().stream()
+            .map(
+                ea ->
+                    ea.getBoundArtifact() == null
+                        ? ea
+                        : ea.toBuilder().boundArtifact(canonicalize(ea.getBoundArtifact())).build())
+            .collect(ImmutableList.toImmutableList());
+    return ArtifactResolver.ResolveResult.create(resolvedArtifacts, resolvedExpectedArtifacts);
+  }
+
+  private static boolean needsCanonicalization(Artifact artifact) {
+    if (!DOCKER_IMAGE_TYPE.equals(artifact.getType())) {
+      return false;
+    }
+    if (LATEST.equals(artifact.getVersion())) {
+      return true;
+    }
+    String reference = artifact.getReference();
+    return reference != null && reference.endsWith(":" + LATEST);
+  }
+}

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolver.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolver.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+
+/**
+ * Replaces a docker/image artifact whose tag is a moving alias (e.g. {@code latest}) with a
+ * canonical pinned-version artifact. Implementations look up the registry to find a stable semver
+ * tag that shares the same digest as the moving alias.
+ *
+ * <p>Implementations are registered via Spring and consulted by {@link
+ * DockerLatestResolutionService}. An implementation should return {@code true} from {@link
+ * #handles(Artifact)} only for references it knows how to resolve (e.g., a specific registry
+ * pattern).
+ */
+public interface DockerLatestResolver {
+
+  /** Whether this resolver knows how to canonicalize the given artifact's reference. */
+  boolean handles(Artifact artifact);
+
+  /**
+   * Resolve the artifact's moving alias to its canonical pinned tag, returning a new artifact with
+   * both {@code version} and {@code reference} updated. Implementations must throw if no canonical
+   * tag can be determined; silent fall-through reintroduces the bug this resolver exists to fix.
+   */
+  Artifact canonicalize(Artifact artifact);
+}

--- a/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionServiceTest.java
+++ b/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionServiceTest.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.pipeline.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.collect.ImmutableList;
+import com.netflix.spinnaker.kork.artifacts.model.Artifact;
+import com.netflix.spinnaker.kork.artifacts.model.ExpectedArtifact;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+final class DockerLatestResolutionServiceTest {
+
+  private static final String LATEST_REF =
+      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
+  private static final String RESOLVED_REF =
+      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
+
+  private static Artifact dockerLatest() {
+    return Artifact.builder()
+        .type("docker/image")
+        .name("moderne/recipe-worker-arm64")
+        .version("latest")
+        .reference(LATEST_REF)
+        .build();
+  }
+
+  private static Artifact dockerResolved() {
+    return Artifact.builder()
+        .type("docker/image")
+        .name("moderne/recipe-worker-arm64")
+        .version("0.147.3")
+        .reference(RESOLVED_REF)
+        .build();
+  }
+
+  @Test
+  void noResolversRegistered_passesThrough() {
+    DockerLatestResolutionService service = new DockerLatestResolutionService(null);
+    assertThat(service.canonicalize(dockerLatest())).isEqualTo(dockerLatest());
+  }
+
+  @Test
+  void canonicalizesArtifactWhenResolverHandlesIt() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(true, dockerResolved())));
+    Artifact result = service.canonicalize(dockerLatest());
+    assertThat(result.getVersion()).isEqualTo("0.147.3");
+    assertThat(result.getReference()).isEqualTo(RESOLVED_REF);
+  }
+
+  @Test
+  void leavesNonDockerArtifactsUnchanged() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(true, dockerResolved())));
+    Artifact gceImage =
+        Artifact.builder().type("google/image").name("my-gce").version("latest").build();
+    assertThat(service.canonicalize(gceImage)).isEqualTo(gceImage);
+  }
+
+  @Test
+  void leavesAlreadyPinnedDockerArtifactsUnchanged() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(true, dockerResolved())));
+    Artifact pinned =
+        Artifact.builder()
+            .type("docker/image")
+            .name("moderne/recipe-worker-arm64")
+            .version("0.147.3")
+            .reference(RESOLVED_REF)
+            .build();
+    assertThat(service.canonicalize(pinned)).isEqualTo(pinned);
+  }
+
+  @Test
+  void detectsLatestViaReferenceWhenVersionFieldEmpty() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(true, dockerResolved())));
+    Artifact noVersion =
+        Artifact.builder()
+            .type("docker/image")
+            .name("moderne/recipe-worker-arm64")
+            .reference(LATEST_REF)
+            .build();
+    Artifact result = service.canonicalize(noVersion);
+    assertThat(result.getVersion()).isEqualTo("0.147.3");
+  }
+
+  @Test
+  void noHandlingResolver_passesThroughUnchanged() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(false, dockerResolved())));
+    assertThat(service.canonicalize(dockerLatest())).isEqualTo(dockerLatest());
+  }
+
+  @Test
+  void resolverThrows_propagates() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(
+            List.of(
+                new DockerLatestResolver() {
+                  @Override
+                  public boolean handles(Artifact artifact) {
+                    return true;
+                  }
+
+                  @Override
+                  public Artifact canonicalize(Artifact artifact) {
+                    throw new IllegalStateException("registry hiccup");
+                  }
+                }));
+    assertThatThrownBy(() -> service.canonicalize(dockerLatest()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("registry hiccup");
+  }
+
+  @Test
+  void canonicalize_resolveResult_rewritesBothLists() {
+    DockerLatestResolutionService service =
+        new DockerLatestResolutionService(List.of(new StubResolver(true, dockerResolved())));
+
+    ExpectedArtifact expected =
+        ExpectedArtifact.builder()
+            .id("img")
+            .matchArtifact(Artifact.builder().type("docker/image").build())
+            .boundArtifact(dockerLatest())
+            .build();
+
+    ArtifactResolver.ResolveResult input =
+        ArtifactResolver.ResolveResult.create(
+            ImmutableList.of(dockerLatest()), ImmutableList.of(expected));
+
+    ArtifactResolver.ResolveResult out = service.canonicalize(input);
+    assertThat(out.getResolvedArtifacts()).hasSize(1);
+    assertThat(out.getResolvedArtifacts().get(0).getVersion()).isEqualTo("0.147.3");
+    assertThat(out.getResolvedExpectedArtifacts().get(0).getBoundArtifact().getVersion())
+        .isEqualTo("0.147.3");
+  }
+
+  private static final class StubResolver implements DockerLatestResolver {
+    private final boolean handles;
+    private final Artifact result;
+
+    StubResolver(boolean handles, Artifact result) {
+      this.handles = handles;
+      this.result = result;
+    }
+
+    @Override
+    public boolean handles(Artifact artifact) {
+      return handles;
+    }
+
+    @Override
+    public Artifact canonicalize(Artifact artifact) {
+      return result;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

Pipelines using `findArtifactFromExecution` with a `docker/image` default of `:latest` (see moderne-saas `metapipelines.libsonnet:107` `findLastDeployedImage`) record `latest` as the deployed-image artifact when:
- a tenant is being paved for the first time (no prior deploy execution to match)
- someone manually triggers `deploy-<tenant>` with `tag=latest`

A subsequent `repave-<tenant>` then resolves the prior artifact, picks up `latest` again, and deploys whatever code happens to be tagged `latest` at that moment, instead of the pinned version the SOC 2 base-image refresh policy expects.

The Spinnaker status board (moderne-saas `infra/status/src/data/spinnakerUrls.ts:56`) also can't map `latest` to a GitHub release link.

## Fix

A new `DockerLatestResolver` SPI in `orca-core` plus a `DockerLatestResolutionService` that post-processes `ArtifactResolver.ResolveResult` outputs: any `docker/image` artifact whose `version` is `latest` (or whose `reference` ends `:latest`) is rewritten to the highest stable semver tag (`^\d+\.\d+\.\d+$`) sharing the same digest. RC tags and SNAPSHOT-timestamped tags are excluded.

Hooked into all three ArtifactResolver call sites, so canonicalization fires:
- at trigger-time binding (`ArtifactUtils.resolveArtifacts(pipeline)`) — covers first-pave and manual deploys
- in `findArtifactFromExecution` — covers repave's prior-artifact lookup
- in `bindProducedArtifacts` — covers stage-context expected artifacts

Match resolution still runs against original artifacts, so any pipeline template matching `matchArtifact.version=latest` keeps working; canonicalization applies only to the resolved bound artifact.

Failure modes (no peer semver, registry error, auth failure) fail the resolution loudly rather than silently passing `latest` through — fixing the underlying bug, not papering over it.

## ECR vs ACR

`EcrDockerTagResolver` in `clouddriver-ecs` does the digest→tags lookup via `DescribeImages`, exposed as `GET /ecs/images/resolveDockerTag`, reused from orca through `OortService.resolveDockerTag`. Reuses the existing `AmazonClientProvider` / `NetflixECSCredentials` wiring; no new auth path.

ACR support is deferred. moderne-saas tenants on AWS *and* Azure pull from the same ECR registry today (`cloudinit.libsonnet:88` uses `aws ecr get-login-password` for both). The SPI shape supports adding an `AzureDockerLatestResolver` when ACR enters the picture without further refactor.

## moderne-saas changes

None. Canonicalization is transparent at the resolver layer, so `findLastDeployedImage` and `tenantDeployPipeline` jsonnets stay as-is.

## Test plan

- [x] `DockerLatestResolutionServiceTest` (orca-core) — 8 tests: no-resolvers passthrough, canonicalization happy path, non-docker passthrough, already-pinned passthrough, reference-only `latest` detection, no-handling-resolver passthrough, error propagation, and the `ResolveResult` rewrite end-to-end.
- [x] `EcrDockerTagResolverTest` (clouddriver-ecs) — 7 tests: highest semver wins, RC/SNAPSHOT excluded, only-`latest` throws, missing image throws, numeric (not lex) semver compare (`0.10.0 > 0.9.9`), invalid ECR reference rejected, reference parsing.
- [x] `EcrDockerLatestResolverTest` (orca-clouddriver) — 6 tests: ECR reference matched, Docker Hub not handled, null reference safe, OortService call rewrites artifact, incomplete response throws, transport error propagates.
- [x] Existing `BindProducedArtifactsTaskTest`, `ArtifactUtilsTest`, `ArtifactResolverTest`, `FindArtifactFromPipelineExecutionTaskTest`, `DependentPipelineStarterTest` still pass — backward-compat constructors keep test sites unchanged.
- [ ] Manual: deploy this orca + clouddriver to dev, trigger a `deploy-<tenant>` with `tag=latest` on a tenant whose registry has both `latest` and a recent semver, verify the recorded artifact has `version=N.N.N` and `reference=…:N.N.N`. Confirm the status board renders a clickable GitHub release link for that cell.