### PR TITLE
[AWS] Skip blank keyPair on launch template create

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/services/LaunchTemplateService.java
@@ -385,13 +385,16 @@ public class LaunchTemplateService {
             .withInstanceType(asgConfig.getInstanceType())
             .withRamDiskId(asgConfig.getRamdiskId())
             .withEbsOptimized(asgConfig.getEbsOptimized())
-            .withKeyName(asgConfig.getKeyPair())
             .withIamInstanceProfile(
                 new LaunchTemplateIamInstanceProfileSpecificationRequest()
                     .withName(asgConfig.getIamRole()))
             .withMonitoring(
                 new LaunchTemplatesMonitoringRequest()
                     .withEnabled(asgConfig.getInstanceMonitoring()));
+
+    if (StringUtils.isNotBlank(asgConfig.getKeyPair())) {
+      request.withKeyName(asgConfig.getKeyPair());
+    }
 
     Optional<LaunchTemplateTagSpecificationRequest> tagSpecification =
         tagSpecification(amazonResourceTaggers, asgConfig.getBlockDeviceTags(), asgName);


### PR DESCRIPTION
EC2 Auto Scaling rejects an explicitly empty KeyName with "Invalid value '' for keyPairNames. It should not be blank", which prevents creating an ASG without an SSH key. Mirror the MODIFY-path behavior at line 235 and only call withKeyName when the configured keyPair is non-blank, so a blank value results in the field being omitted from the AWS request entirely.