### PR TITLE
[Azure] Pass full-ARM-ID UAMIs through to ARM template verbatim

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/templates/AzureServerGroupResourceTemplate.groovy
@@ -503,8 +503,17 @@ class AzureServerGroupResourceTemplate {
 
   // ***Scale Set User assigned and optionaly system assigned Identity
   static class UserAndOptionalSystemAssignedIdentity extends ManagedIdentity {
-    // user assigned identities needs to be added in the following format
-    // "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/','<identityname>')]" : { }
+    // user assigned identities are added in one of two forms:
+    //   - bare name `<identityname>` → wrapped as
+    //     "[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/','<identityname>')]" : { }
+    //     (resolves in the deployment's resource group; the historical default).
+    //   - full ARM resource ID
+    //     `/subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.ManagedIdentity/userAssignedIdentities/<name>`
+    //     → emitted verbatim. ARM's `resourceID()` only resolves same-RG
+    //     references, so a UAMI in a different RG than the VMSS deployment
+    //     (e.g. shared per-tenant identity in `<tenant>` while the VMSS lands
+    //     in `<app>-<region>`) requires the full ID. Detected by the
+    //     `/subscriptions/` prefix.
     Map<String, Map<String, String>> userAssignedIdentities = [:]
 
     /**
@@ -515,7 +524,10 @@ class AzureServerGroupResourceTemplate {
       type = enableSystemAssigned ? ResourceIdentityType.SYSTEM_ASSIGNED_USER_ASSIGNED.toString() : ResourceIdentityType.USER_ASSIGNED
       if (userAssignedIdentities.length() > 0) {
         for (String identity : userAssignedIdentities.split(",")) {
-          this.userAssignedIdentities.put(String.format("[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/','%s')]", identity), [:])
+          String key = identity.startsWith("/subscriptions/")
+              ? identity
+              : String.format("[resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/','%s')]", identity)
+          this.userAssignedIdentities.put(key, [:])
         }
       }
     }


### PR DESCRIPTION
## Summary

When `description.userAssignedIdentities` is a full ARM resource ID (starts with `/subscriptions/`), emit it directly as the `identity.userAssignedIdentities` map key instead of wrapping with `resourceID('Microsoft.ManagedIdentity/userAssignedIdentities/', '<id>')`. ARM's `resourceID()` only resolves same-RG references, so a UAMI that lives in a different RG than the VMSS deployment cannot be referenced that way and produces:

> Unable to evaluate template language function 'resourceID': function requires exactly one multi-segmented argument which must be resource type including resource provider namespace.

Bare-name inputs continue to take the existing wrap path (no behavior change for the historical case). Detected by the unambiguous `/subscriptions/` prefix.

## Why we hit this

Concrete use case: tenant-shared UAMI in a `<tenant>-v2` RG, VMSS deployed into per-app `<app>-<region>` RGs (the convention `AzureUtilities.getResourceGroupName(application, region)` produces). Both ends are reasonable Azure topologies; `resourceID()` just can't bridge across RGs in a 2-arg form. Preserving the full ARM ID through to the template fixes it without changing anything else.

## Test plan

- [ ] Verified existing `'generate server group with userAssignedIdentities'` and `'... without useSystemManagedIdentity'` Spock tests still pass (bare-name path unchanged).
- [ ] Deploy attempt against devaz fails with the `resourceID` template error pre-patch.
- [ ] Deploy attempt against devaz succeeds post-patch (UAMI map key is the full ARM ID).