### PR TITLE
[Azure] surface underlying ARM error when LRO deployment fails

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -26,6 +26,8 @@ import com.azure.resourcemanager.resources.models.DeploymentOperation
 import com.azure.resourcemanager.resources.models.Provider
 import com.azure.resourcemanager.resources.models.ResourceGroup
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
+import com.netflix.spinnaker.clouddriver.azure.resources.common.model.AzureDeploymentOperation
+import com.netflix.spinnaker.clouddriver.azure.resources.common.model.AzureDeploymentOperation.FailedResourceDetail
 import groovy.transform.CompileStatic
 import groovy.util.logging.Slf4j
 
@@ -222,12 +224,87 @@ class AzureResourceManagerClient extends AzureBaseClient {
           .withMode(deploymentMode)
           .create()
       })
-    } catch (Throwable e) {
-      log.error("Exception occured during deployment ${e.message}")
-      throw e
+    } catch (Exception e) {
+      String original = e.message ?: "${e.class.simpleName} (no message)".toString()
+      String enriched = enrichWithDeploymentOperationErrors(
+        original,
+        lookupDeploymentOperationsForErrorEnrichment(resourceGroupName, deploymentName))
+      log.error("Exception occured during deployment ${deploymentName}: ${enriched}", e)
+      throw wrapAsRichException(enriched, e)
     } finally {
       logDeploymentTemplate(deploymentName, template, templateParameters)
     }
+  }
+
+  /**
+   * Wrap an exception with an enriched message while preserving the original exception type
+   * when it is a {@link ManagementException}, so downstream {@code catch (ManagementException)}
+   * blocks continue to match.
+   */
+  static RuntimeException wrapAsRichException(String enrichedMessage, Exception original) {
+    if (original instanceof ManagementException) {
+      ManagementException me = (ManagementException) original
+      ManagementException enriched = new ManagementException(enrichedMessage, me.response, me.value)
+      enriched.initCause(original)
+      return enriched
+    }
+    new RuntimeException(enrichedMessage, original)
+  }
+
+  /**
+   * Best-effort lookup of deployment operations so that the original LRO failure can be enriched
+   * with the underlying ARM error details. Performs a small bounded retry to ride out the
+   * race window between LRO terminal-failure and ARM materializing the per-op failure rows.
+   * Returns an empty list (rather than propagating) if every attempt fails or 404s, since at
+   * this point we already have an exception to surface.
+   */
+  private static final int LOOKUP_RETRY_ATTEMPTS = 3
+  private static final long LOOKUP_RETRY_BACKOFF_MS = 1000
+
+  private Collection<DeploymentOperation> lookupDeploymentOperationsForErrorEnrichment(
+    String resourceGroupName, String deploymentName) {
+    Exception lastEx = null
+    for (int attempt = 0; attempt < LOOKUP_RETRY_ATTEMPTS; attempt++) {
+      if (attempt > 0) {
+        try {
+          Thread.sleep(LOOKUP_RETRY_BACKOFF_MS)
+        } catch (InterruptedException ie) {
+          Thread.currentThread().interrupt()
+          break
+        }
+      }
+      try {
+        Collection<DeploymentOperation> ops = getDeploymentOperations(resourceGroupName, deploymentName)
+        if (ops) {
+          return ops
+        }
+      } catch (Exception lookupEx) {
+        lastEx = lookupEx
+      }
+    }
+    if (lastEx != null) {
+      log.warn("Failed to fetch deployment operations for ${deploymentName} while enriching error", lastEx)
+    }
+    Collections.<DeploymentOperation> emptyList()
+  }
+
+  /**
+   * Build a richer error message by appending each FAILED deployment operation's statusMessage to
+   * the original exception message. Azure's LRO poller throws a generic
+   * "Long running operation failed." with no details — the actual ARM error lives in each
+   * operation's statusMessage. Stale failures from prior retries (deployment names are
+   * deterministic) are filtered out via timestamp windowing.
+   */
+  static String enrichWithDeploymentOperationErrors(
+    String originalMessage,
+    Collection<DeploymentOperation> operations) {
+    List<FailedResourceDetail> failures = AzureDeploymentOperation.extractFailedResources(operations)
+    failures = AzureDeploymentOperation.filterToRecentFailures(failures)
+    if (!failures) {
+      return originalMessage
+    }
+    String joined = failures.collect { "[${it.label()}] ${it.statusMessageRendered}".toString() }.join(' | ')
+    "${originalMessage} :: ${joined}".toString()
   }
 
   static void logDeploymentTemplate(String deploymentName, String template, Map<String, Object> parameters) {

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/model/AzureDeploymentOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/model/AzureDeploymentOperation.groovy
@@ -16,15 +16,21 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.common.model
 
+import com.azure.core.management.exception.ManagementError
 import com.azure.resourcemanager.resources.fluent.models.DeploymentOperationInner
 import com.azure.resourcemanager.resources.models.DeploymentOperation
+import com.azure.resourcemanager.resources.models.DeploymentOperationProperties
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import groovy.transform.CompileStatic
+import groovy.transform.TupleConstructor
 import groovy.util.logging.Slf4j
+
+import java.time.Duration
+import java.time.OffsetDateTime
 
 @CompileStatic
 @Slf4j
@@ -75,9 +81,7 @@ class AzureDeploymentOperation {
           } else if (inner.properties().provisioningState() == AzureUtilities.ProvisioningState.FAILED) {
             if (!resourceCompletedState[inner.id()]) {
 
-              //String statusMessage = updatedDeploymentOperation?.value?.first()?.properties?.statusMessage?.error?.message
-              String err = "Failed to create resource ${inner.properties().targetResource().resourceName()}: "
-              err += inner.properties().statusMessage() ? inner.properties().statusMessage() : "See Azure Portal for more information."
+              String err = "Failed to create resource ${inner.properties().targetResource().resourceName()}: ${renderStatusMessage(inner.properties().statusMessage())}"
               task.updateStatus opsName, err
               resourceCompletedState[inner.id()] = true
               errList.add(err)
@@ -111,6 +115,94 @@ class AzureDeploymentOperation {
       deploymentState != AzureUtilities.ProvisioningState.DELETED &&
       deploymentState != AzureUtilities.ProvisioningState.FAILED &&
       deploymentState != AzureUtilities.ProvisioningState.SUCCEEDED
+  }
+
+  /**
+   * Extract structured failure details from a list of deployment operations. Skips operations
+   * whose targetResource is null (a known SDK quirk where an extra "wrapper" operation is
+   * returned that doesn't correspond to any real ARM resource).
+   */
+  static List<FailedResourceDetail> extractFailedResources(Collection<DeploymentOperation> operations) {
+    if (!operations) {
+      return []
+    }
+    List<FailedResourceDetail> failures = []
+    for (DeploymentOperation op : operations) {
+      DeploymentOperationInner inner = op?.innerModel()
+      DeploymentOperationProperties props = inner?.properties()
+      if (props == null) continue
+      if (props.provisioningState() != AzureUtilities.ProvisioningState.FAILED) continue
+      if (props.targetResource() == null) continue
+      failures << new FailedResourceDetail(
+        operationId: inner.id(),
+        resourceName: props.targetResource().resourceName(),
+        resourceType: props.targetResource().resourceType() ?: "",
+        timestamp: props.timestamp(),
+        statusMessageRendered: renderStatusMessage(props.statusMessage())
+      )
+    }
+    failures
+  }
+
+  /**
+   * Filter to failures whose timestamp is within {@code window} of the most recent failure.
+   * Used by the LRO failure-enrichment path to avoid attaching stale failures from previous
+   * retries of a deterministically-named deployment.
+   *
+   * Failures with a null timestamp are kept (defensive: we can't decide without data).
+   */
+  static List<FailedResourceDetail> filterToRecentFailures(
+    List<FailedResourceDetail> failures, Duration window = Duration.ofMinutes(5)) {
+    if (!failures) return []
+    OffsetDateTime latest = null
+    for (FailedResourceDetail f : failures) {
+      if (f.timestamp != null && (latest == null || f.timestamp.isAfter(latest))) {
+        latest = f.timestamp
+      }
+    }
+    if (latest == null) return failures
+    OffsetDateTime cutoff = latest.minus(window)
+    failures.findAll { it.timestamp == null || !it.timestamp.isBefore(cutoff) }
+  }
+
+  /**
+   * Render the {@link com.azure.resourcemanager.resources.models.StatusMessage StatusMessage}
+   * of a deployment operation as a human-readable string. Prefers the structured ManagementError
+   * (code + message) when present.
+   */
+  static String renderStatusMessage(Object statusMessage) {
+    if (statusMessage == null) {
+      return "(no Azure error details)"
+    }
+    // Defensive: the typed property returns StatusMessage but the interface returns Object.
+    if (statusMessage instanceof com.azure.resourcemanager.resources.models.StatusMessage) {
+      def sm = (com.azure.resourcemanager.resources.models.StatusMessage) statusMessage
+      ManagementError error = sm.error()
+      if (error != null) {
+        List<String> parts = []
+        if (error.code) parts << error.code
+        if (error.message) parts << error.message
+        if (parts) {
+          return parts.join(': ')
+        }
+        return error.toString()
+      }
+      return sm.status() ?: sm.toString()
+    }
+    statusMessage.toString()
+  }
+
+  @TupleConstructor
+  static class FailedResourceDetail {
+    String operationId
+    String resourceName
+    String resourceType
+    OffsetDateTime timestamp
+    String statusMessageRendered
+
+    String label() {
+      resourceType ? "${resourceType}/${resourceName}" : resourceName
+    }
   }
 
   List<OpsValue> value

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClientSpec.groovy
@@ -1,0 +1,262 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.client
+
+import com.azure.core.http.HttpResponse
+import com.azure.core.management.exception.ManagementError
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.resources.fluent.models.DeploymentOperationInner
+import com.azure.resourcemanager.resources.models.DeploymentOperation
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import spock.lang.Specification
+
+class AzureResourceManagerClientSpec extends Specification {
+
+  static final ObjectMapper MAPPER = new ObjectMapper()
+    .registerModule(new JavaTimeModule())
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  static DeploymentOperationInner inner(String json) {
+    MAPPER.readValue(json, DeploymentOperationInner.class)
+  }
+
+  def "enrichWithDeploymentOperationErrors returns the original message when there are no operations"() {
+    expect:
+    AzureResourceManagerClient.enrichWithDeploymentOperationErrors("Long running operation failed.", []) ==
+      "Long running operation failed."
+  }
+
+  def "enrichWithDeploymentOperationErrors returns the original message when no operations failed"() {
+    given:
+    def succeededInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "targetResource": {"resourceName": "my-nic", "resourceType": "Microsoft.Network/networkInterfaces"}
+        }
+      }''')
+    def succeeded = Mock(DeploymentOperation)
+    succeeded.innerModel() >> succeededInner
+
+    expect:
+    AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [succeeded]) == "Long running operation failed."
+  }
+
+  def "enrichWithDeploymentOperationErrors appends statusMessage from a single FAILED operation"() {
+    given:
+    def failedInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:00Z",
+          "statusMessage": {
+            "error": {
+              "code": "InvalidTemplate",
+              "message": "Resource Microsoft.Compute/virtualMachineScaleSets does not support availability zones at location 'westus'."
+            }
+          },
+          "targetResource": {"resourceName": "my-vmss", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def failed = Mock(DeploymentOperation)
+    failed.innerModel() >> failedInner
+
+    when:
+    def enriched = AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [failed])
+
+    then:
+    enriched.startsWith("Long running operation failed.")
+    enriched.contains("my-vmss")
+    enriched.contains("InvalidTemplate")
+    enriched.contains("does not support availability zones at location 'westus'")
+  }
+
+  def "enrichWithDeploymentOperationErrors joins multiple FAILED operations and skips successful ones"() {
+    given:
+    def failedAInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:00Z",
+          "statusMessage": {"error": {"code": "InvalidTemplate", "message": "first error"}},
+          "targetResource": {"resourceName": "vmss-a", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def failedBInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:01Z",
+          "statusMessage": {"error": {"code": "InvalidResourceReference", "message": "second error"}},
+          "targetResource": {"resourceName": "lb-b", "resourceType": "Microsoft.Network/loadBalancers"}
+        }
+      }''')
+    def succeededInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "targetResource": {"resourceName": "nic-c", "resourceType": "Microsoft.Network/networkInterfaces"}
+        }
+      }''')
+    def failedA = Mock(DeploymentOperation)
+    failedA.innerModel() >> failedAInner
+    def failedB = Mock(DeploymentOperation)
+    failedB.innerModel() >> failedBInner
+    def succeeded = Mock(DeploymentOperation)
+    succeeded.innerModel() >> succeededInner
+
+    when:
+    def enriched = AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [failedA, succeeded, failedB])
+
+    then:
+    enriched.contains("vmss-a")
+    enriched.contains("first error")
+    enriched.contains("lb-b")
+    enriched.contains("second error")
+    !enriched.contains("nic-c")
+    enriched.contains(" | ")
+  }
+
+  def "enrichWithDeploymentOperationErrors falls back gracefully when statusMessage is absent"() {
+    given:
+    def failedInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:00Z",
+          "targetResource": {"resourceName": "orphan", "resourceType": "Microsoft.Resources/deployments"}
+        }
+      }''')
+    def failed = Mock(DeploymentOperation)
+    failed.innerModel() >> failedInner
+
+    when:
+    def enriched = AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [failed])
+
+    then:
+    enriched.startsWith("Long running operation failed.")
+    enriched.contains("orphan")
+  }
+
+  def "enrichWithDeploymentOperationErrors skips operations missing a target resource (SDK noise)"() {
+    given:
+    def phantomInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:00Z",
+          "statusMessage": {"error": {"code": "DeploymentFailed", "message": "phantom op with no target"}}
+        }
+      }''')
+    def realInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T20:00:00Z",
+          "statusMessage": {"error": {"code": "InvalidTemplate", "message": "real failure"}},
+          "targetResource": {"resourceName": "my-vmss", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def phantom = Mock(DeploymentOperation)
+    phantom.innerModel() >> phantomInner
+    def real = Mock(DeploymentOperation)
+    real.innerModel() >> realInner
+
+    when:
+    def enriched = AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [phantom, real])
+
+    then:
+    !enriched.contains("phantom op")
+    !enriched.contains("<unknown>")
+    enriched.contains("my-vmss")
+    enriched.contains("real failure")
+  }
+
+  def "enrichWithDeploymentOperationErrors filters out stale failures from prior retries by timestamp"() {
+    given:
+    // Two failures: one from 30 minutes ago (stale prior attempt), one fresh (~now in window)
+    def staleInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T19:00:00Z",
+          "statusMessage": {"error": {"code": "OldError", "message": "stale failure from prior retry"}},
+          "targetResource": {"resourceName": "stale-resource", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def freshInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "timestamp": "2026-05-07T19:30:00Z",
+          "statusMessage": {"error": {"code": "FreshError", "message": "actual current failure"}},
+          "targetResource": {"resourceName": "fresh-resource", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def stale = Mock(DeploymentOperation)
+    stale.innerModel() >> staleInner
+    def fresh = Mock(DeploymentOperation)
+    fresh.innerModel() >> freshInner
+
+    when:
+    def enriched = AzureResourceManagerClient.enrichWithDeploymentOperationErrors(
+      "Long running operation failed.", [stale, fresh])
+
+    then:
+    !enriched.contains("stale failure from prior retry")
+    !enriched.contains("stale-resource")
+    enriched.contains("fresh-resource")
+    enriched.contains("actual current failure")
+  }
+
+  def "wrapAsRichException preserves ManagementException type"() {
+    given:
+    def response = Mock(HttpResponse) { getStatusCode() >> 400 }
+    def value = new ManagementError("Original", "original message")
+    def original = new ManagementException("Long running operation failed.", response, value)
+
+    when:
+    def wrapped = AzureResourceManagerClient.wrapAsRichException("enriched message", original)
+
+    then:
+    wrapped instanceof ManagementException
+    wrapped.message == "enriched message"
+    ((ManagementException) wrapped).getResponse() == response
+    ((ManagementException) wrapped).getValue() == value
+    wrapped.cause == original
+  }
+
+  def "wrapAsRichException wraps non-Management exceptions in RuntimeException"() {
+    given:
+    def original = new IllegalStateException("boom")
+
+    when:
+    def wrapped = AzureResourceManagerClient.wrapAsRichException("enriched", original)
+
+    then:
+    wrapped.class == RuntimeException
+    wrapped.message == "enriched"
+    wrapped.cause == original
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/model/AzureDeploymentOperationSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/common/model/AzureDeploymentOperationSpec.groovy
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2026 Harness, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.common.model
+
+import com.azure.core.management.exception.ManagementError
+import com.azure.resourcemanager.resources.fluent.models.DeploymentOperationInner
+import com.azure.resourcemanager.resources.models.DeploymentOperation
+import com.azure.resourcemanager.resources.models.StatusMessage
+import com.azure.resourcemanager.resources.models.TargetResource
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.time.Duration
+import java.time.OffsetDateTime
+
+class AzureDeploymentOperationSpec extends Specification {
+
+  static final ObjectMapper MAPPER = new ObjectMapper()
+    .registerModule(new JavaTimeModule())
+    .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+
+  static DeploymentOperationInner inner(String json) {
+    MAPPER.readValue(json, DeploymentOperationInner.class)
+  }
+
+  def "extractFailedResources returns empty for null/empty input"() {
+    expect:
+    AzureDeploymentOperation.extractFailedResources(null) == []
+    AzureDeploymentOperation.extractFailedResources([]) == []
+  }
+
+  def "extractFailedResources skips ops with null targetResource (SDK noise filter)"() {
+    given:
+    def phantomInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "statusMessage": {"error": {"code": "X", "message": "phantom"}}
+        }
+      }''')
+    def realInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Failed",
+          "statusMessage": {"error": {"code": "Y", "message": "real"}},
+          "targetResource": {"resourceName": "vmss", "resourceType": "Microsoft.Compute/virtualMachineScaleSets"}
+        }
+      }''')
+    def phantom = Mock(DeploymentOperation)
+    phantom.innerModel() >> phantomInner
+    def real = Mock(DeploymentOperation)
+    real.innerModel() >> realInner
+
+    when:
+    def result = AzureDeploymentOperation.extractFailedResources([phantom, real])
+
+    then:
+    result.size() == 1
+    result[0].resourceName == "vmss"
+  }
+
+  def "extractFailedResources skips Succeeded operations"() {
+    given:
+    def succeededInner = inner('''
+      {
+        "properties": {
+          "provisioningState": "Succeeded",
+          "targetResource": {"resourceName": "ok", "resourceType": "Microsoft.Network/networkInterfaces"}
+        }
+      }''')
+    def succeeded = Mock(DeploymentOperation)
+    succeeded.innerModel() >> succeededInner
+
+    expect:
+    AzureDeploymentOperation.extractFailedResources([succeeded]) == []
+  }
+
+  def "filterToRecentFailures keeps only failures within window of the most recent timestamp"() {
+    given:
+    def t = { OffsetDateTime ts ->
+      new AzureDeploymentOperation.FailedResourceDetail("op", "r", "T", ts, "msg")
+    }
+    def latest = OffsetDateTime.parse("2026-05-07T20:00:00Z")
+    def stale = t(latest.minusMinutes(30))
+    def borderline = t(latest.minusMinutes(4))
+    def fresh = t(latest)
+
+    when:
+    def kept = AzureDeploymentOperation.filterToRecentFailures([stale, borderline, fresh], Duration.ofMinutes(5))
+
+    then:
+    kept.size() == 2
+    kept.contains(borderline)
+    kept.contains(fresh)
+    !kept.contains(stale)
+  }
+
+  def "filterToRecentFailures returns input when no timestamps are present (defensive)"() {
+    given:
+    def f1 = new AzureDeploymentOperation.FailedResourceDetail("op1", "r1", "T", null, "msg1")
+    def f2 = new AzureDeploymentOperation.FailedResourceDetail("op2", "r2", "T", null, "msg2")
+
+    expect:
+    AzureDeploymentOperation.filterToRecentFailures([f1, f2], Duration.ofMinutes(5)) == [f1, f2]
+  }
+
+  def "filterToRecentFailures keeps null-timestamp failures defensively"() {
+    given:
+    def latest = OffsetDateTime.parse("2026-05-07T20:00:00Z")
+    def fresh = new AzureDeploymentOperation.FailedResourceDetail("op1", "r1", "T", latest, "fresh")
+    def unknown = new AzureDeploymentOperation.FailedResourceDetail("op2", "r2", "T", null, "unknown")
+
+    when:
+    def kept = AzureDeploymentOperation.filterToRecentFailures([fresh, unknown], Duration.ofMinutes(5))
+
+    then:
+    kept.size() == 2
+  }
+
+  @Unroll
+  def "renderStatusMessage handles #scenario"() {
+    expect:
+    AzureDeploymentOperation.renderStatusMessage(input) == expected
+
+    where:
+    scenario                              | input                                                                                       | expected
+    "null status"                         | null                                                                                        | "(no Azure error details)"
+    "error with code and message"         | new StatusMessage().withError(new ManagementError("InvalidTemplate", "details here"))       | "InvalidTemplate: details here"
+    "error with code only"                | new StatusMessage().withError(new ManagementError("OnlyCode", null))                        | "OnlyCode"
+    "error with message only"             | new StatusMessage().withError(new ManagementError(null, "only-msg"))                        | "only-msg"
+    "no error, status only"               | new StatusMessage().withStatus("Cancelled")                                                 | "Cancelled"
+    "non-StatusMessage object"            | "raw string from interface API"                                                             | "raw string from interface API"
+  }
+
+  def "FailedResourceDetail.label combines type and name when type present"() {
+    expect:
+    new AzureDeploymentOperation.FailedResourceDetail(
+      "op", "vmss", "Microsoft.Compute/virtualMachineScaleSets", null, "msg").label() ==
+      "Microsoft.Compute/virtualMachineScaleSets/vmss"
+  }
+
+  def "FailedResourceDetail.label is just name when type is empty"() {
+    expect:
+    new AzureDeploymentOperation.FailedResourceDetail("op", "vmss", "", null, "msg").label() == "vmss"
+  }
+}


### PR DESCRIPTION
## Summary
- Azure SDK's LRO poller throws `AzureException("Long running operation failed.")` with no detail when an ARM deployment terminates in `Failed`. The actual ARM error (e.g. `does not support availability zones at location 'westus'`, `InvalidResourceReference`, `properties.upgradePolicy.mode = null`) lives in each `DeploymentOperation.statusMessage` and was previously only extracted on the success polling path. On failure, clouddriver surfaced only the SDK's generic message to the Spinnaker UI, leaving operators to dig through clouddriver logs.
- `AzureResourceManagerClient.createTemplateDeployment` now catches the exception, queries the deployment's operations, and rethrows with each `FAILED` operation's `statusMessage` appended: `<original> :: [<resourceType>/<resourceName>] <code>: <message> | ...`.
- Hardening: bounded retry (3×1s) on the operation lookup to ride out the ARM eventual-consistency race; timestamp window filter so deterministic deployment-name retries don't surface stale prior-attempt errors; null-`targetResource` filter to suppress known SDK noise; `ManagementException` type preserved when rethrowing so downstream `catch (ManagementException)` blocks keep matching; catch narrowed from `Throwable` to `Exception` so JVM `Error`s propagate cleanly; null `e.message` defaults to a sensible class-name string.
- DRY: `renderStatusMessage`, `extractFailedResources`, and `filterToRecentFailures` extracted to `AzureDeploymentOperation`. The success-path `checkDeploymentOperationStatus` and the new failure path now share the rendering logic.

## Test plan
- New `AzureResourceManagerClientSpec` (8 tests): empty/all-succeeded → original message; single FAILED appends statusMessage; multiple FAILED + Succeeded interleaved; missing statusMessage / missing targetResource / phantom null-target ops; stale failures filtered by timestamp window; `wrapAsRichException` preserves `ManagementException` type and wraps non-Management exceptions in `RuntimeException`.
- New `AzureDeploymentOperationSpec` (9 tests): `extractFailedResources` skips null-target SDK noise, skips Succeeded, returns empty for null/empty input; `filterToRecentFailures` keeps within window / handles missing timestamps / keeps null-timestamp failures defensively; `renderStatusMessage` handles null / code+message / code-only / message-only / status-only / non-StatusMessage object; `FailedResourceDetail.label()` formatting.
- `./gradlew :clouddriver:clouddriver-azure:test` runs all 17 new tests green; broader azure suite goes 177 → 194 tests with the same 25 pre-existing template/converter failures (verified by stashing this diff and re-running on the unmodified branch — same failures, unrelated).