### PR TITLE
Fix Azure image finder gallery version selection

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupController.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupController.groovy
@@ -359,16 +359,9 @@ class AzureVMImageLookupController {
   List<AzureNamedImage> findImagesByTags(LookupOptions lookupOptions) {
     def results = [] as List<AzureNamedImage>
 
-    // If the caller explicitly asked for one source (managedImages=true OR
-    // galleryImages=true), respect that. If both flags are false/null (legacy
-    // callers that don't set either), search both -- this preserves the
-    // historical "tags imply both sources" behavior so this change is a no-op
-    // until a caller opts in.
-    boolean anyExplicit = lookupOptions.managedImages || lookupOptions.galleryImages
-    boolean searchManaged = anyExplicit ? lookupOptions.managedImages : true
-    boolean searchGallery = anyExplicit ? lookupOptions.galleryImages : true
-
-    if (searchManaged) {
+    // Honor the LookupOptions flags directly. Defaults are managedImages=false
+    // and galleryImages=true, so a caller that sets neither gets gallery-only.
+    if (lookupOptions.managedImages) {
       def pattern = Keys.getManagedVMImageKey(azureCloudProvider,
         lookupOptions.account ?: '*',
         lookupOptions.region ?: '*',
@@ -395,7 +388,7 @@ class AzureVMImageLookupController {
       }
     }
 
-    if (searchGallery && results.size() < MAX_SEARCH_RESULTS) {
+    if (lookupOptions.galleryImages && results.size() < MAX_SEARCH_RESULTS) {
       def galleryPattern = Keys.getGalleryImageKey(azureCloudProvider,
         lookupOptions.account ?: '*',
         lookupOptions.region ?: '*',
@@ -529,7 +522,12 @@ class AzureVMImageLookupController {
     Boolean configOnly = true
     Boolean customOnly = false
     Boolean managedImages = false
-    Boolean galleryImages = false
+    // Default to true: Shared Image Gallery is the canonical deploy-time image
+    // form on Azure (bake produces a managed image in the bake region, then a
+    // replication step publishes gallery image versions everywhere else).
+    // Callers that only want managed/custom/marketplace results can set this
+    // to false explicitly.
+    Boolean galleryImages = true
     Map<String, String> tags
   }
 }

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupController.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupController.groovy
@@ -359,34 +359,43 @@ class AzureVMImageLookupController {
   List<AzureNamedImage> findImagesByTags(LookupOptions lookupOptions) {
     def results = [] as List<AzureNamedImage>
 
-    // Search managed images
-    def pattern = Keys.getManagedVMImageKey(azureCloudProvider,
-      lookupOptions.account ?: '*',
-      lookupOptions.region ?: '*',
-      "*", "*", "*")
+    // If the caller explicitly asked for one source (managedImages=true OR
+    // galleryImages=true), respect that. If both flags are false/null (legacy
+    // callers that don't set either), search both -- this preserves the
+    // historical "tags imply both sources" behavior so this change is a no-op
+    // until a caller opts in.
+    boolean anyExplicit = lookupOptions.managedImages || lookupOptions.galleryImages
+    boolean searchManaged = anyExplicit ? lookupOptions.managedImages : true
+    boolean searchGallery = anyExplicit ? lookupOptions.galleryImages : true
 
-    def identifiers = cacheView.filterIdentifiers(Keys.Namespace.AZURE_MANAGEDIMAGES.ns, pattern)
-    def data = cacheView.getAll(Keys.Namespace.AZURE_MANAGEDIMAGES.ns, identifiers, RelationshipCacheFilter.none())
+    if (searchManaged) {
+      def pattern = Keys.getManagedVMImageKey(azureCloudProvider,
+        lookupOptions.account ?: '*',
+        lookupOptions.region ?: '*',
+        "*", "*", "*")
 
-    for (cacheData in data) {
-      try {
-        AzureManagedVMImage vmImage = objectMapper.convertValue(cacheData.attributes['vmimage'], AzureManagedVMImage)
-        def parts = Keys.parse(azureCloudProvider, cacheData.id)
+      def identifiers = cacheView.filterIdentifiers(Keys.Namespace.AZURE_MANAGEDIMAGES.ns, pattern)
+      def data = cacheView.getAll(Keys.Namespace.AZURE_MANAGEDIMAGES.ns, identifiers, RelationshipCacheFilter.none())
 
-        if (matchesFilters(vmImage, lookupOptions)) {
-          results += buildAzureNamedImage(vmImage, parts)
+      for (cacheData in data) {
+        try {
+          AzureManagedVMImage vmImage = objectMapper.convertValue(cacheData.attributes['vmimage'], AzureManagedVMImage)
+          def parts = Keys.parse(azureCloudProvider, cacheData.id)
 
-          if (results.size() >= MAX_SEARCH_RESULTS) {
-            break
+          if (matchesFilters(vmImage, lookupOptions)) {
+            results += buildAzureNamedImage(vmImage, parts)
+
+            if (results.size() >= MAX_SEARCH_RESULTS) {
+              break
+            }
           }
+        } catch (Exception e) {
+          log.error("findImagesByTags -> Unexpected exception", e)
         }
-      } catch (Exception e) {
-        log.error("findImagesByTags -> Unexpected exception", e)
       }
     }
 
-    // Also search gallery images
-    if (results.size() < MAX_SEARCH_RESULTS) {
+    if (searchGallery && results.size() < MAX_SEARCH_RESULTS) {
       def galleryPattern = Keys.getGalleryImageKey(azureCloudProvider,
         lookupOptions.account ?: '*',
         lookupOptions.region ?: '*',

--- a/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupControllerTest.java
+++ b/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupControllerTest.java
@@ -767,4 +767,146 @@ class AzureVMImageLookupControllerTest {
     assertThat(result.getIsCustom()).isTrue();
     assertThat(result.getUri()).contains("/galleries/" + GALLERY_NAME);
   }
+
+  @Test
+  @DisplayName(
+      "findImagesByTags with managedImages=true alone skips the gallery cache (callers can pin a source)")
+  void findImagesByTagsRespectsManagedOnly() {
+    // prepare
+    LookupOptions lookupOptions = new LookupOptions();
+    lookupOptions.setAccount(AZURE_ACCOUNT);
+    lookupOptions.setRegion(REGION);
+    lookupOptions.setManagedImages(true);
+    // galleryImages stays false -- caller explicitly wants managed only
+    lookupOptions.setTags(Map.of("appversion", "1.0.0"));
+
+    String managedKey =
+        Keys.getManagedVMImageKey(
+            azureCloudProvider, AZURE_ACCOUNT, REGION, RESOURCE_GROUP, VM_IMAGE_NAME, OS_TYPE);
+    var managedImage = new AzureManagedVMImage();
+    managedImage.setName(VM_IMAGE_NAME);
+    managedImage.setRegion(REGION);
+    managedImage.setOsType(OS_TYPE);
+    managedImage.setResourceGroup(RESOURCE_GROUP);
+    managedImage.setTags(Map.of("appversion", "1.0.0"));
+    Map<String, Object> managedImageMap =
+        objectMapper.convertValue(managedImage, new TypeReference<>() {});
+    CacheData managedCacheData =
+        new DefaultCacheData(managedKey, Map.of("vmimage", managedImageMap), Map.of());
+
+    given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString()))
+        .willReturn(List.of(managedKey));
+    given(
+            cache.getAll(
+                eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyList(), any(CacheFilter.class)))
+        .willReturn(List.of(managedCacheData));
+
+    // credentials needed for buildAzureNamedImage
+    var mockCreds =
+        mock(com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials.class);
+    var mockAzureCreds =
+        mock(com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials.class);
+    given(mockCreds.getCredentials()).willReturn(mockAzureCreds);
+    given(mockAzureCreds.getSubscriptionId()).willReturn(SUBSCRIPTION_ID);
+    doReturn(mockCreds).when(accountCredentialsProvider).getCredentials(AZURE_ACCOUNT);
+
+    // act
+    List<AzureNamedImage> results =
+        lookupController.list(lookupOptions, Map.of("tag:appversion", "1.0.0"));
+
+    // assert: managed found, gallery cache never touched
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getImageName()).isEqualTo(VM_IMAGE_NAME);
+    verify(cache, never())
+        .filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString());
+    verify(cache, never())
+        .getAll(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyList(), any(CacheFilter.class));
+  }
+
+  @Test
+  @DisplayName(
+      "findImagesByTags with galleryImages=true alone skips the managed cache (devaz path)")
+  void findImagesByTagsRespectsGalleryOnly() {
+    // prepare
+    LookupOptions lookupOptions = new LookupOptions();
+    lookupOptions.setAccount(AZURE_ACCOUNT);
+    lookupOptions.setRegion(REGION);
+    lookupOptions.setGalleryImages(true);
+    // managedImages stays false
+    lookupOptions.setTags(Map.of("appversion", "1.0.0"));
+
+    String galleryKey =
+        Keys.getGalleryImageKey(
+            azureCloudProvider,
+            AZURE_ACCOUNT,
+            REGION,
+            RESOURCE_GROUP,
+            GALLERY_NAME,
+            IMAGE_DEF_NAME,
+            GALLERY_VERSION,
+            OS_TYPE);
+    Map<String, Object> galleryImageMap = getGalleryImageAsJsonMap();
+    CacheData galleryCacheData =
+        new DefaultCacheData(galleryKey, Map.of("vmimage", galleryImageMap), Map.of());
+    given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString()))
+        .willReturn(List.of(galleryKey));
+    given(
+            cache.getAll(
+                eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyList(), any(CacheFilter.class)))
+        .willReturn(List.of(galleryCacheData));
+
+    var mockCreds =
+        mock(com.netflix.spinnaker.clouddriver.azure.security.AzureNamedAccountCredentials.class);
+    var mockAzureCreds =
+        mock(com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials.class);
+    given(mockCreds.getCredentials()).willReturn(mockAzureCreds);
+    given(mockAzureCreds.getSubscriptionId()).willReturn(SUBSCRIPTION_ID);
+    doReturn(mockCreds).when(accountCredentialsProvider).getCredentials(AZURE_ACCOUNT);
+
+    // act
+    List<AzureNamedImage> results =
+        lookupController.list(lookupOptions, Map.of("tag:appversion", "1.0.0"));
+
+    // assert: gallery found, managed cache never touched
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).getImageName()).isEqualTo(IMAGE_DEF_NAME);
+    verify(cache, never())
+        .filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString());
+    verify(cache, never())
+        .getAll(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyList(), any(CacheFilter.class));
+  }
+
+  @Test
+  @DisplayName(
+      "findImagesByTags with neither flag set still searches both (backward compat for legacy callers)")
+  void findImagesByTagsDefaultsToBothWhenNoFlagSet() {
+    // prepare
+    LookupOptions lookupOptions = new LookupOptions();
+    lookupOptions.setAccount(AZURE_ACCOUNT);
+    lookupOptions.setRegion(REGION);
+    // neither managedImages nor galleryImages set -- existing callers
+    lookupOptions.setTags(Map.of("appversion", "1.0.0"));
+
+    given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString()))
+        .willReturn(List.of());
+    given(
+            cache.getAll(
+                eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyList(), any(CacheFilter.class)))
+        .willReturn(List.of());
+    given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString()))
+        .willReturn(List.of());
+    given(
+            cache.getAll(
+                eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyList(), any(CacheFilter.class)))
+        .willReturn(List.of());
+
+    // act
+    lookupController.list(lookupOptions, Map.of("tag:appversion", "1.0.0"));
+
+    // assert: both caches were consulted (backward compat)
+    verify(cache, times(1))
+        .filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString());
+    verify(cache, times(1))
+        .filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString());
+  }
 }

--- a/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupControllerTest.java
+++ b/clouddriver/clouddriver-azure/src/test/java/com/netflix/spinnaker/clouddriver/azure/resources/vmimage/view/AzureVMImageLookupControllerTest.java
@@ -599,6 +599,10 @@ class AzureVMImageLookupControllerTest {
     lookupOptions.setManagedImages(managedImage);
     lookupOptions.setCustomOnly(customOnly);
     lookupOptions.setConfigOnly(configOnly);
+    // These pre-gallery tests assert against a fixed set of namespaces; pin
+    // galleryImages=false so the now-true LookupOptions default doesn't add
+    // an extra gallery-cache lookup that they aren't expecting.
+    lookupOptions.setGalleryImages(false);
     return lookupOptions;
   }
 
@@ -770,14 +774,16 @@ class AzureVMImageLookupControllerTest {
 
   @Test
   @DisplayName(
-      "findImagesByTags with managedImages=true alone skips the gallery cache (callers can pin a source)")
+      "findImagesByTags with managedImages=true and galleryImages=false searches only managed")
   void findImagesByTagsRespectsManagedOnly() {
     // prepare
     LookupOptions lookupOptions = new LookupOptions();
     lookupOptions.setAccount(AZURE_ACCOUNT);
     lookupOptions.setRegion(REGION);
     lookupOptions.setManagedImages(true);
-    // galleryImages stays false -- caller explicitly wants managed only
+    // galleryImages defaults to true, so callers wanting managed-only must
+    // override it explicitly.
+    lookupOptions.setGalleryImages(false);
     lookupOptions.setTags(Map.of("appversion", "1.0.0"));
 
     String managedKey =
@@ -878,21 +884,14 @@ class AzureVMImageLookupControllerTest {
 
   @Test
   @DisplayName(
-      "findImagesByTags with neither flag set still searches both (backward compat for legacy callers)")
-  void findImagesByTagsDefaultsToBothWhenNoFlagSet() {
-    // prepare
+      "findImagesByTags with neither flag set inherits LookupOptions defaults (gallery-only)")
+  void findImagesByTagsDefaultsToGalleryOnly() {
+    // prepare -- caller sets neither flag; defaults apply (managed=false, gallery=true)
     LookupOptions lookupOptions = new LookupOptions();
     lookupOptions.setAccount(AZURE_ACCOUNT);
     lookupOptions.setRegion(REGION);
-    // neither managedImages nor galleryImages set -- existing callers
     lookupOptions.setTags(Map.of("appversion", "1.0.0"));
 
-    given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString()))
-        .willReturn(List.of());
-    given(
-            cache.getAll(
-                eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyList(), any(CacheFilter.class)))
-        .willReturn(List.of());
     given(cache.filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString()))
         .willReturn(List.of());
     given(
@@ -903,10 +902,10 @@ class AzureVMImageLookupControllerTest {
     // act
     lookupController.list(lookupOptions, Map.of("tag:appversion", "1.0.0"));
 
-    // assert: both caches were consulted (backward compat)
-    verify(cache, times(1))
-        .filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString());
+    // assert: gallery cache consulted, managed cache untouched
     verify(cache, times(1))
         .filterIdentifiers(eq(Keys.Namespace.AZURE_GALLERYIMAGES.getNs()), anyString());
+    verify(cache, never())
+        .filterIdentifiers(eq(Keys.Namespace.AZURE_MANAGEDIMAGES.getNs()), anyString());
   }
 }

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
@@ -46,15 +46,13 @@ public class AzureImageFinder implements ImageFinder {
         regions,
         account);
 
-    // Deploys consume Shared Image Gallery versions exclusively: bake produces
-    // a managed image in a single bake region, then a replication step
-    // publishes gallery image versions into every deploy region. Asking the
-    // controller for managed images here would either return nothing (in
-    // regions the bake doesn't touch) or collide with gallery results on
-    // lexicographic name compare. Hard-coding gallery-only sidesteps both.
+    // Image-source flags inherit their LookupOptions defaults on the
+    // controller side: managedImages=false, galleryImages=true. Deploys
+    // consume Shared Image Gallery versions exclusively (bake produces a
+    // managed image in a single region, replication publishes gallery
+    // versions everywhere else), so the defaults already express what we
+    // want -- no need to set either flag here.
     Map<String, String> searchParams = new HashMap<>(prefixTags(tags));
-    searchParams.put("managedImages", "false");
-    searchParams.put("galleryImages", "true");
 
     List<AzureManagedImage> allMatchedImages =
         Retrofit2SyncCall.execute(

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
@@ -46,8 +46,28 @@ public class AzureImageFinder implements ImageFinder {
         regions,
         account);
 
+    // Image source selection: managed-only (the historical AWS-parity shape),
+    // gallery-only (Shared Image Gallery -- the canonical replicated form for
+    // regions the bake doesn't bake into directly), or both. Default is "both",
+    // matching the controller's pre-gating behavior. A pipeline pins this via
+    // stage.context.imageSource.
+    String imageSource = stageData.imageSource;
+    boolean wantManaged = imageSource == null
+        || imageSource.equalsIgnoreCase("managed")
+        || imageSource.equalsIgnoreCase("both");
+    boolean wantGallery = imageSource == null
+        || imageSource.equalsIgnoreCase("gallery")
+        || imageSource.equalsIgnoreCase("both");
+    if (!wantManaged && !wantGallery) {
+      throw new IllegalArgumentException(
+          "imageSource must be one of \"managed\", \"gallery\", or \"both\" (got: "
+              + imageSource
+              + ")");
+    }
+
     Map<String, String> searchParams = new HashMap<>(prefixTags(tags));
-    searchParams.put("managedImages", "true");
+    searchParams.put("managedImages", String.valueOf(wantManaged));
+    searchParams.put("galleryImages", String.valueOf(wantGallery));
 
     List<AzureManagedImage> allMatchedImages =
         Retrofit2SyncCall.execute(
@@ -94,6 +114,12 @@ public class AzureImageFinder implements ImageFinder {
     @JsonProperty List<String> regions;
     @JsonProperty String packageName;
     @JsonProperty Map<String, String> tags;
+    // Optional. One of "managed" (managed images only), "gallery" (Shared
+    // Image Gallery only), or "both" (default, current behavior). Pinning to
+    // "gallery" prevents the comparator from being asked to choose between a
+    // managed image and a gallery image in the same region -- the regression
+    // captured by AzureImageFinderSpec#byTags exposes the documented gap.
+    @JsonProperty String imageSource;
   }
 
   static class AzureManagedImage implements Comparable<AzureManagedImage> {
@@ -102,6 +128,11 @@ public class AzureImageFinder implements ImageFinder {
     @JsonProperty String region;
     @JsonProperty String osType;
     @JsonProperty String uri;
+    // Set only for Shared Image Gallery results, where all versions of an
+    // image definition share the same `imageName` (= imageDefinitionName) and
+    // the version is what actually distinguishes them. Managed-image results
+    // leave this null and rely on the timestamp embedded in `imageName`.
+    @JsonProperty String version;
     @JsonProperty Map<String, Object> attributes;
     @JsonProperty Map<String, String> tags;
 
@@ -115,14 +146,53 @@ public class AzureImageFinder implements ImageFinder {
                           tags.get("build_host"), av.getBuildJobName(), av.getBuildNumber()))
               .orElse(null);
 
-      return new AzureImageDetails(imageName, region, resourceGroup, osType, uri, jenkinsDetails);
+      return new AzureImageDetails(
+          imageName, region, resourceGroup, osType, uri, version, jenkinsDetails);
     }
 
     @Override
     public int compareTo(AzureManagedImage other) {
-      // Sort by name (reverse alphabetical to get latest versions)
-      return other.imageName.compareTo(this.imageName);
+      // Sort by name first (reverse alphabetical to get latest versions).
+      int byName = other.imageName.compareTo(this.imageName);
+      if (byName != 0) {
+        return byName;
+      }
+      // Names tie -- this is the gallery-image case, where every version of
+      // an image definition reports the same imageName. Without a tiebreaker
+      // the dedup-per-region loop downstream picks a random version. Compare
+      // by `version` (descending) so the highest version wins.
+      return compareVersions(other.version, this.version);
     }
+  }
+
+  // Numeric-aware comparison for Shared Image Gallery versions, which Azure
+  // requires to be `MAJOR.MINOR.PATCH` integers. Falls back to lexicographic
+  // comparison for any non-numeric component so an unexpected format degrades
+  // gracefully instead of throwing.
+  static int compareVersions(String a, String b) {
+    if (a == null || a.isEmpty()) {
+      return (b == null || b.isEmpty()) ? 0 : -1;
+    }
+    if (b == null || b.isEmpty()) {
+      return 1;
+    }
+    String[] aParts = a.split("\\.");
+    String[] bParts = b.split("\\.");
+    int n = Math.max(aParts.length, bParts.length);
+    for (int i = 0; i < n; i++) {
+      String aPart = i < aParts.length ? aParts[i] : "0";
+      String bPart = i < bParts.length ? bParts[i] : "0";
+      int cmp;
+      try {
+        cmp = Long.compare(Long.parseLong(aPart), Long.parseLong(bPart));
+      } catch (NumberFormatException e) {
+        cmp = aPart.compareTo(bPart);
+      }
+      if (cmp != 0) {
+        return cmp;
+      }
+    }
+    return 0;
   }
 
   static class AzureImageDetails extends HashMap<String, Object> implements ImageDetails {
@@ -132,6 +202,7 @@ public class AzureImageFinder implements ImageFinder {
         String resourceGroup,
         String osType,
         String uri,
+        String version,
         JenkinsDetails jenkinsDetails) {
       put("imageName", imageName);
       String imageId = (uri != null && !uri.isEmpty() && !uri.equals("na")) ? uri : "na";
@@ -139,6 +210,10 @@ public class AzureImageFinder implements ImageFinder {
       put("region", region);
       put("resourceGroup", resourceGroup);
       put("osType", osType);
+
+      if (version != null && !version.isEmpty()) {
+        put("version", version);
+      }
 
       if (jenkinsDetails != null) {
         put("jenkins", jenkinsDetails);

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
@@ -46,13 +46,12 @@ public class AzureImageFinder implements ImageFinder {
         regions,
         account);
 
-    // Image-source flags inherit their LookupOptions defaults on the
-    // controller side: managedImages=false, galleryImages=true. Deploys
-    // consume Shared Image Gallery versions exclusively (bake produces a
-    // managed image in a single region, replication publishes gallery
-    // versions everywhere else), so the defaults already express what we
-    // want -- no need to set either flag here.
+    // Ask the controller for both managed and gallery image candidates --
+    // managedImages=true here, galleryImages=true inherits from LookupOptions'
+    // default. Source preference between the two (gallery wins on tie) is the
+    // comparator's job (see AzureManagedImage#compareTo).
     Map<String, String> searchParams = new HashMap<>(prefixTags(tags));
+    searchParams.put("managedImages", "true");
 
     List<AzureManagedImage> allMatchedImages =
         Retrofit2SyncCall.execute(
@@ -131,7 +130,21 @@ public class AzureImageFinder implements ImageFinder {
 
     @Override
     public int compareTo(AzureManagedImage other) {
-      // Sort by name first (reverse alphabetical to get latest versions).
+      // Source preference: when both a gallery image and a managed image are
+      // candidates in the same region, gallery wins. Gallery is the canonical
+      // replicated/deploy-time form on Azure, and a lex compare on imageName
+      // would otherwise be unsafe -- a stable gallery imageDefinitionName like
+      // "moderne-arm64-noble" can sort either side of a timestamped managed
+      // name like "moderne-1746961200000-noble-arm64". Gallery rows expose a
+      // non-null `version`; managed rows don't, which is what we discriminate
+      // on here.
+      boolean thisIsGallery = this.version != null && !this.version.isEmpty();
+      boolean otherIsGallery = other.version != null && !other.version.isEmpty();
+      if (thisIsGallery != otherIsGallery) {
+        return thisIsGallery ? -1 : 1;
+      }
+
+      // Same source. Sort by name first (reverse alphabetical to get latest versions).
       int byName = other.imageName.compareTo(this.imageName);
       if (byName != 0) {
         return byName;

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
@@ -46,28 +46,15 @@ public class AzureImageFinder implements ImageFinder {
         regions,
         account);
 
-    // Image source selection: managed-only (the historical AWS-parity shape),
-    // gallery-only (Shared Image Gallery -- the canonical replicated form for
-    // regions the bake doesn't bake into directly), or both. Default is "both",
-    // matching the controller's pre-gating behavior. A pipeline pins this via
-    // stage.context.imageSource.
-    String imageSource = stageData.imageSource;
-    boolean wantManaged = imageSource == null
-        || imageSource.equalsIgnoreCase("managed")
-        || imageSource.equalsIgnoreCase("both");
-    boolean wantGallery = imageSource == null
-        || imageSource.equalsIgnoreCase("gallery")
-        || imageSource.equalsIgnoreCase("both");
-    if (!wantManaged && !wantGallery) {
-      throw new IllegalArgumentException(
-          "imageSource must be one of \"managed\", \"gallery\", or \"both\" (got: "
-              + imageSource
-              + ")");
-    }
-
+    // Deploys consume Shared Image Gallery versions exclusively: bake produces
+    // a managed image in a single bake region, then a replication step
+    // publishes gallery image versions into every deploy region. Asking the
+    // controller for managed images here would either return nothing (in
+    // regions the bake doesn't touch) or collide with gallery results on
+    // lexicographic name compare. Hard-coding gallery-only sidesteps both.
     Map<String, String> searchParams = new HashMap<>(prefixTags(tags));
-    searchParams.put("managedImages", String.valueOf(wantManaged));
-    searchParams.put("galleryImages", String.valueOf(wantGallery));
+    searchParams.put("managedImages", "false");
+    searchParams.put("galleryImages", "true");
 
     List<AzureManagedImage> allMatchedImages =
         Retrofit2SyncCall.execute(
@@ -114,12 +101,6 @@ public class AzureImageFinder implements ImageFinder {
     @JsonProperty List<String> regions;
     @JsonProperty String packageName;
     @JsonProperty Map<String, String> tags;
-    // Optional. One of "managed" (managed images only), "gallery" (Shared
-    // Image Gallery only), or "both" (default, current behavior). Pinning to
-    // "gallery" prevents the comparator from being asked to choose between a
-    // managed image and a gallery image in the same region -- the regression
-    // captured by AzureImageFinderSpec#byTags exposes the documented gap.
-    @JsonProperty String imageSource;
   }
 
   static class AzureManagedImage implements Comparable<AzureManagedImage> {

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
@@ -49,6 +49,20 @@ class AzureImageFinderSpec extends Specification {
     ]
   }
 
+  // Wire shape for a managed image: timestamped imageName, no `version` field
+  // (Jackson drops keys absent from AzureManagedImage, so omitting `version`
+  // here matches what production responses look like for managed entries).
+  private static Map managedImageWireShape(
+      String region, String name, Map<String, String> tags) {
+    [
+        imageName: name,
+        region   : region,
+        uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
+                   "Microsoft.Compute/images/${name}".toString(),
+        tags     : tags,
+    ]
+  }
+
   def "compareVersions orders semver numerically, not lexicographically"() {
     expect:
     Integer.signum(AzureImageFinder.compareVersions(a, b)) == expected
@@ -66,6 +80,22 @@ class AzureImageFinderSpec extends Specification {
     null         | null         | 0
     ""           | "1.0.0"      | -1
     "1.0.0-rc1"  | "1.0.0-rc2"  | -1  // non-numeric falls back to lex
+  }
+
+  def "AzureManagedImage compareTo prefers gallery over managed when both candidate in the same region"() {
+    given: "a gallery image (has version) and a managed image (no version), names that would lex either way"
+    def gallery = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-arm64-noble",  // 'a' > '1' on the next char
+        version: "2026.5.1",  // intentionally OLDER than the managed bake
+        region: "canadacentral")
+    def managed = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-1746961200000-noble-arm64",
+        version: null,
+        region: "canadacentral")
+
+    expect: "gallery sorts first regardless of name lex or relative age"
+    gallery.compareTo(managed) < 0
+    managed.compareTo(gallery) > 0
   }
 
   def "AzureManagedImage compareTo tiebreaks on version when imageDefinitionName ties"() {
@@ -123,10 +153,11 @@ class AzureImageFinderSpec extends Specification {
         [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
         [])
 
-    then: "clouddriver inherits gallery-only from LookupOptions defaults; the finder sends no image-source flags"
+    then: "finder asks for managed; gallery defaults to true on LookupOptions so both caches are searched"
     1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
         "tag:moderne_base"   : "true",
         "tag:moderne_base_os": "ubuntu-arm64-24.04",
+        "managedImages"      : "true",
     ]) >> Calls.response([
         galleryImageWireShape("westus", "2026.5.8", baseTags),
         galleryImageWireShape("westus", "2026.5.10", baseTags),
@@ -231,5 +262,38 @@ class AzureImageFinderSpec extends Specification {
     then:
     thrown(IllegalArgumentException)
     0 * oortService._
+  }
+
+  def "byTags picks gallery over managed in the same region (the documented gap is closed)"() {
+    // Mixed managed + gallery in canadacentral: bake produces the managed
+    // image and the replication step publishes a gallery version pointing at
+    // the same content. Before the comparator's source preference, gallery
+    // would beat managed on lex (or lose, depending on names). Now gallery
+    // wins unconditionally when both are candidates -- gallery is the
+    // canonical deploy-time form.
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["canadacentral"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then: "clouddriver returns both: a fresh managed image and an older gallery version"
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
+        managedImageWireShape("canadacentral",
+            "moderne-1746961200000-noble-arm64", baseTags),
+        galleryImageWireShape("canadacentral", "2026.5.1", baseTags),
+    ])
+    0 * _
+
+    and: "gallery wins on source preference, not on lex or age"
+    imageDetails.size() == 1
+    imageDetails.first().imageName == "moderne-arm64-noble"
+    imageDetails.first().get("version") == "2026.5.1"
+    imageDetails.first().imageId.contains("/galleries/")
   }
 }

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
@@ -1,0 +1,404 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.orca.clouddriver.tasks.providers.azure
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.netflix.spinnaker.orca.clouddriver.OortService
+import com.netflix.spinnaker.orca.pipeline.model.PipelineExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
+import retrofit2.mock.Calls
+import spock.lang.Specification
+import spock.lang.Subject
+import spock.lang.Unroll
+
+class AzureImageFinderSpec extends Specification {
+
+  def objectMapper = new ObjectMapper()
+  def oortService = Mock(OortService)
+
+  @Subject
+  def azureImageFinder = new AzureImageFinder(objectMapper: objectMapper, oortService: oortService)
+
+  // Wire shape that AzureVMImageLookupController#buildGalleryAzureNamedImage emits
+  // for Shared Image Gallery results: stable imageName (= imageDefinitionName),
+  // version segregated, URI carries the full gallery resource path. (Field names
+  // here match the finder's AzureManagedImage POJO so a stock ObjectMapper can
+  // round-trip them in the test -- the controller-side wire field names that
+  // don't map cleanly, like `ostype`, are dropped in production by Jackson
+  // configuration and aren't relevant to selection.)
+  private static Map galleryImageWireShape(String region, String version, Map<String, String> tags) {
+    [
+        imageName: "moderne-arm64-noble",
+        version  : version,
+        region   : region,
+        uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
+                   "Microsoft.Compute/galleries/moderne/images/" +
+                   "moderne-arm64-noble/versions/${version}".toString(),
+        tags     : tags,
+    ]
+  }
+
+  // Wire shape for managed-image results: timestamp baked into imageName, no
+  // version field.
+  private static Map managedImageWireShape(String region, String name, Map<String, String> tags) {
+    [
+        imageName: name,
+        region   : region,
+        uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
+                   "Microsoft.Compute/images/${name}".toString(),
+        tags     : tags,
+    ]
+  }
+
+  def "compareVersions orders semver numerically, not lexicographically"() {
+    expect:
+    Integer.signum(AzureImageFinder.compareVersions(a, b)) == expected
+
+    where:
+    a            | b            | expected
+    "1.10.0"     | "1.9.0"      | 1   // numeric: 10 > 9
+    "1.9.0"      | "1.10.0"     | -1
+    "2026.5.10"  | "2026.5.9"   | 1
+    "1.0.0"      | "1.0.0"      | 0
+    "1.0"        | "1.0.0"      | 0   // missing components treated as 0
+    "1.0.1"      | "1.0"        | 1
+    null         | "1.0.0"      | -1
+    "1.0.0"      | null         | 1
+    null         | null         | 0
+    ""           | "1.0.0"      | -1
+    "1.0.0-rc1"  | "1.0.0-rc2"  | -1  // non-numeric falls back to lex
+  }
+
+  def "AzureManagedImage compareTo tiebreaks on version when imageName ties (gallery case)"() {
+    given: "two gallery image versions with the same imageDefinitionName"
+    def older = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-arm64-noble",
+        version: "2026.5.9",
+        region: "westus")
+    def newer = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-arm64-noble",
+        version: "2026.5.10",
+        region: "westus")
+
+    expect: "the newer version sorts first (compareTo < 0)"
+    newer.compareTo(older) < 0
+    older.compareTo(newer) > 0
+  }
+
+  def "AzureManagedImage compareTo falls back to imageName when names differ"() {
+    given: "two managed images named with epoch-ms timestamps; gallery version absent"
+    def today = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-1746961200000-noble-arm64",
+        region: "canadacentral")
+    def yesterday = new AzureImageFinder.AzureManagedImage(
+        imageName: "moderne-1746874800000-noble-arm64",
+        region: "canadacentral")
+
+    expect: "alphabetically (= numerically, same prefix) later name sorts first"
+    today.compareTo(yesterday) < 0
+    yesterday.compareTo(today) > 0
+  }
+
+  def "dedup-per-region loop picks the highest-version gallery image"() {
+    given: "three gallery image versions of the same definition, in cache-arrival order"
+    def images = [
+        new AzureImageFinder.AzureManagedImage(
+            imageName: "moderne-arm64-noble", version: "2026.5.8", region: "westus"),
+        new AzureImageFinder.AzureManagedImage(
+            imageName: "moderne-arm64-noble", version: "2026.5.10", region: "westus"),
+        new AzureImageFinder.AzureManagedImage(
+            imageName: "moderne-arm64-noble", version: "2026.5.9", region: "westus"),
+    ]
+
+    when: "applying the same selection logic as AzureImageFinder#byTags"
+    def sorted = images.toSorted()
+    def latest = [:]
+    sorted.each { image ->
+      def existing = latest[image.region]
+      if (existing == null || image.compareTo(existing) < 0) {
+        latest[image.region] = image
+      }
+    }
+
+    then: "the newest version wins regardless of cache arrival order"
+    latest["westus"].version == "2026.5.10"
+  }
+
+  def "byTags picks the highest gallery version when cache returns versions out of order (devaz scenario)"() {
+    given: "a deploy stage targeting westus -- the devaz tenant scenario"
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["westus"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(
+        stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
+        [])
+
+    then: "clouddriver returns three gallery versions of the same image definition, out of order"
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
+        "tag:moderne_base"   : "true",
+        "tag:moderne_base_os": "ubuntu-arm64-24.04",
+        "managedImages"      : "true",
+        "galleryImages"      : "true",
+    ]) >> Calls.response([
+        galleryImageWireShape("westus", "2026.5.8", baseTags),
+        galleryImageWireShape("westus", "2026.5.10", baseTags),
+        galleryImageWireShape("westus", "2026.5.9", baseTags),
+    ])
+    0 * _
+
+    and: "byTags returns exactly the newest version's URI"
+    imageDetails.size() == 1
+    def selected = imageDetails.first()
+    selected.region == "westus"
+    selected.imageName == "moderne-arm64-noble"
+    selected.imageId.endsWith("/versions/2026.5.10")
+    selected.get("version") == "2026.5.10"
+  }
+
+  def "byTags filters out images from regions the deploy doesn't target"() {
+    given: "deploy targets westus; canadacentral is the bake region only"
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["westus"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(
+        stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
+        [])
+
+    then: "clouddriver returns the fresh managed image (canadacentral) AND replicated gallery (westus)"
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
+        managedImageWireShape("canadacentral",
+            "moderne-1746961200000-noble-arm64", baseTags),
+        galleryImageWireShape("westus", "2026.5.10", baseTags),
+    ])
+    0 * _
+
+    and: "only the westus gallery image is returned; the canadacentral managed image is region-filtered out"
+    imageDetails.size() == 1
+    imageDetails.first().region == "westus"
+    imageDetails.first().imageId.endsWith("/versions/2026.5.10")
+  }
+
+  def "byTags picks the newest version per region when multiple regions are targeted"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["westus", "eastus"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(
+        stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
+        [])
+
+    then:
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
+        galleryImageWireShape("westus", "2026.5.8", baseTags),
+        galleryImageWireShape("westus", "2026.5.10", baseTags),
+        galleryImageWireShape("eastus", "2026.5.7", baseTags),
+        galleryImageWireShape("eastus", "2026.5.9", baseTags),
+    ])
+    0 * _
+
+    and:
+    imageDetails.size() == 2
+    imageDetails.find { it.region == "westus" }.imageId.endsWith("/versions/2026.5.10")
+    imageDetails.find { it.region == "eastus" }.imageId.endsWith("/versions/2026.5.9")
+  }
+
+  def "byTags returns null when clouddriver has no matching images"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["westus"],
+    ])
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then:
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([])
+    0 * _
+
+    and:
+    imageDetails == null
+  }
+
+  def "byTags throws when regions are not specified"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: [],
+    ])
+
+    when:
+    azureImageFinder.byTags(stage, "moderne", [moderne_base: "true"], [])
+
+    then:
+    thrown(IllegalArgumentException)
+    0 * oortService._
+  }
+
+  def "byTags exposes the documented gap when imageSource defaults to both"() {
+    // With default `imageSource`, the controller still returns both kinds when
+    // they coexist in a region. The comparator can't tell that the timestamped
+    // managed name is newer than a stable gallery definitionName, because the
+    // lexicographic compare picks the alphabetically-later string -- 'a' > '1',
+    // so any "moderne-arm64-..." gallery name beats "moderne-<epoch>-..." even
+    // when older. Pinning `imageSource: "gallery"` (next test) avoids this.
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["canadacentral"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then:
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
+        managedImageWireShape("canadacentral",
+            "moderne-1746961200000-noble-arm64", baseTags),
+        galleryImageWireShape("canadacentral", "2026.5.1", baseTags),  // older!
+    ])
+    0 * _
+
+    and: "gallery wins on name, not on version -- known limitation, structural fix is imageSource: gallery"
+    imageDetails.size() == 1
+    imageDetails.first().imageName == "moderne-arm64-noble"
+    imageDetails.first().get("version") == "2026.5.1"
+  }
+
+  def "imageSource=gallery sends only galleryImages=true and structurally avoids the mixed-source gap"() {
+    given: "the devaz-shape pipeline pins imageSource to gallery"
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account    : "moderne-azure",
+        regions    : ["canadacentral"],
+        imageSource: "gallery",
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then: "controller is told to skip managed images entirely; only gallery rows come back"
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
+        "tag:moderne_base"   : "true",
+        "tag:moderne_base_os": "ubuntu-arm64-24.04",
+        "managedImages"      : "false",
+        "galleryImages"      : "true",
+    ]) >> Calls.response([
+        galleryImageWireShape("canadacentral", "2026.5.10", baseTags),
+        galleryImageWireShape("canadacentral", "2026.5.8", baseTags),
+    ])
+    0 * _
+
+    and: "the newest gallery version is selected -- no managed image was ever in the running"
+    imageDetails.size() == 1
+    imageDetails.first().get("version") == "2026.5.10"
+  }
+
+  def "imageSource=managed sends only managedImages=true (AWS-parity tenants)"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account    : "moderne-azure",
+        regions    : ["canadacentral"],
+        imageSource: "managed",
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then:
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
+        "tag:moderne_base"   : "true",
+        "tag:moderne_base_os": "ubuntu-arm64-24.04",
+        "managedImages"      : "true",
+        "galleryImages"      : "false",
+    ]) >> Calls.response([
+        managedImageWireShape("canadacentral",
+            "moderne-1746874800000-noble-arm64", baseTags),
+        managedImageWireShape("canadacentral",
+            "moderne-1746961200000-noble-arm64", baseTags),
+    ])
+    0 * _
+
+    and: "newest timestamp wins"
+    imageDetails.size() == 1
+    imageDetails.first().imageName == "moderne-1746961200000-noble-arm64"
+  }
+
+  def "imageSource is case-insensitive and accepts 'both' explicitly"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account    : "moderne-azure",
+        regions    : ["westus"],
+        imageSource: source,
+    ])
+
+    when:
+    azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then:
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, { Map m ->
+      m["managedImages"] == expectedManaged && m["galleryImages"] == expectedGallery
+    }) >> Calls.response([])
+
+    where:
+    source    | expectedManaged | expectedGallery
+    "gallery" | "false"         | "true"
+    "GALLERY" | "false"         | "true"
+    "managed" | "true"          | "false"
+    "Managed" | "true"          | "false"
+    "both"    | "true"          | "true"
+    "BOTH"    | "true"          | "true"
+  }
+
+  def "byTags throws when imageSource is unrecognised"() {
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account    : "moderne-azure",
+        regions    : ["westus"],
+        imageSource: "nonsense",
+    ])
+
+    when:
+    azureImageFinder.byTags(stage, "moderne", [moderne_base: "true"], [])
+
+    then:
+    thrown(IllegalArgumentException)
+    0 * oortService._
+  }
+}

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
@@ -23,7 +23,6 @@ import com.netflix.spinnaker.orca.pipeline.model.StageExecutionImpl
 import retrofit2.mock.Calls
 import spock.lang.Specification
 import spock.lang.Subject
-import spock.lang.Unroll
 
 class AzureImageFinderSpec extends Specification {
 
@@ -35,31 +34,17 @@ class AzureImageFinderSpec extends Specification {
 
   // Wire shape that AzureVMImageLookupController#buildGalleryAzureNamedImage emits
   // for Shared Image Gallery results: stable imageName (= imageDefinitionName),
-  // version segregated, URI carries the full gallery resource path. (Field names
-  // here match the finder's AzureManagedImage POJO so a stock ObjectMapper can
-  // round-trip them in the test -- the controller-side wire field names that
-  // don't map cleanly, like `ostype`, are dropped in production by Jackson
-  // configuration and aren't relevant to selection.)
-  private static Map galleryImageWireShape(String region, String version, Map<String, String> tags) {
+  // version segregated, URI carries the full gallery resource path.
+  private static Map galleryImageWireShape(
+      String region, String version, Map<String, String> tags,
+      String imageDefinitionName = "moderne-arm64-noble") {
     [
-        imageName: "moderne-arm64-noble",
+        imageName: imageDefinitionName,
         version  : version,
         region   : region,
         uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
                    "Microsoft.Compute/galleries/moderne/images/" +
-                   "moderne-arm64-noble/versions/${version}".toString(),
-        tags     : tags,
-    ]
-  }
-
-  // Wire shape for managed-image results: timestamp baked into imageName, no
-  // version field.
-  private static Map managedImageWireShape(String region, String name, Map<String, String> tags) {
-    [
-        imageName: name,
-        region   : region,
-        uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
-                   "Microsoft.Compute/images/${name}".toString(),
+                   "${imageDefinitionName}/versions/${version}".toString(),
         tags     : tags,
     ]
   }
@@ -83,7 +68,7 @@ class AzureImageFinderSpec extends Specification {
     "1.0.0-rc1"  | "1.0.0-rc2"  | -1  // non-numeric falls back to lex
   }
 
-  def "AzureManagedImage compareTo tiebreaks on version when imageName ties (gallery case)"() {
+  def "AzureManagedImage compareTo tiebreaks on version when imageDefinitionName ties"() {
     given: "two gallery image versions with the same imageDefinitionName"
     def older = new AzureImageFinder.AzureManagedImage(
         imageName: "moderne-arm64-noble",
@@ -97,20 +82,6 @@ class AzureImageFinderSpec extends Specification {
     expect: "the newer version sorts first (compareTo < 0)"
     newer.compareTo(older) < 0
     older.compareTo(newer) > 0
-  }
-
-  def "AzureManagedImage compareTo falls back to imageName when names differ"() {
-    given: "two managed images named with epoch-ms timestamps; gallery version absent"
-    def today = new AzureImageFinder.AzureManagedImage(
-        imageName: "moderne-1746961200000-noble-arm64",
-        region: "canadacentral")
-    def yesterday = new AzureImageFinder.AzureManagedImage(
-        imageName: "moderne-1746874800000-noble-arm64",
-        region: "canadacentral")
-
-    expect: "alphabetically (= numerically, same prefix) later name sorts first"
-    today.compareTo(yesterday) < 0
-    yesterday.compareTo(today) > 0
   }
 
   def "dedup-per-region loop picks the highest-version gallery image"() {
@@ -138,8 +109,8 @@ class AzureImageFinderSpec extends Specification {
     latest["westus"].version == "2026.5.10"
   }
 
-  def "byTags picks the highest gallery version when cache returns versions out of order (devaz scenario)"() {
-    given: "a deploy stage targeting westus -- the devaz tenant scenario"
+  def "byTags picks the highest gallery version when cache returns versions out of order"() {
+    given: "a deploy stage targeting westus"
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
         account: "moderne-azure",
         regions: ["westus"],
@@ -152,11 +123,11 @@ class AzureImageFinderSpec extends Specification {
         [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
         [])
 
-    then: "clouddriver returns three gallery versions of the same image definition, out of order"
+    then: "clouddriver is asked for gallery images only and returns three out-of-order versions"
     1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
         "tag:moderne_base"   : "true",
         "tag:moderne_base_os": "ubuntu-arm64-24.04",
-        "managedImages"      : "true",
+        "managedImages"      : "false",
         "galleryImages"      : "true",
     ]) >> Calls.response([
         galleryImageWireShape("westus", "2026.5.8", baseTags),
@@ -174,8 +145,8 @@ class AzureImageFinderSpec extends Specification {
     selected.get("version") == "2026.5.10"
   }
 
-  def "byTags filters out images from regions the deploy doesn't target"() {
-    given: "deploy targets westus; canadacentral is the bake region only"
+  def "byTags filters out gallery images from regions the deploy doesn't target"() {
+    given: "deploy targets westus; an extra gallery version lives in eastus"
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
         account: "moderne-azure",
         regions: ["westus"],
@@ -188,15 +159,14 @@ class AzureImageFinderSpec extends Specification {
         [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
         [])
 
-    then: "clouddriver returns the fresh managed image (canadacentral) AND replicated gallery (westus)"
+    then: "clouddriver returns gallery images in both regions; only the targeted region survives"
     1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
-        managedImageWireShape("canadacentral",
-            "moderne-1746961200000-noble-arm64", baseTags),
+        galleryImageWireShape("eastus", "2026.5.10", baseTags),
         galleryImageWireShape("westus", "2026.5.10", baseTags),
     ])
     0 * _
 
-    and: "only the westus gallery image is returned; the canadacentral managed image is region-filtered out"
+    and:
     imageDetails.size() == 1
     imageDetails.first().region == "westus"
     imageDetails.first().imageId.endsWith("/versions/2026.5.10")
@@ -255,143 +225,6 @@ class AzureImageFinderSpec extends Specification {
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
         account: "moderne-azure",
         regions: [],
-    ])
-
-    when:
-    azureImageFinder.byTags(stage, "moderne", [moderne_base: "true"], [])
-
-    then:
-    thrown(IllegalArgumentException)
-    0 * oortService._
-  }
-
-  def "byTags exposes the documented gap when imageSource defaults to both"() {
-    // With default `imageSource`, the controller still returns both kinds when
-    // they coexist in a region. The comparator can't tell that the timestamped
-    // managed name is newer than a stable gallery definitionName, because the
-    // lexicographic compare picks the alphabetically-later string -- 'a' > '1',
-    // so any "moderne-arm64-..." gallery name beats "moderne-<epoch>-..." even
-    // when older. Pinning `imageSource: "gallery"` (next test) avoids this.
-    given:
-    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
-        account: "moderne-azure",
-        regions: ["canadacentral"],
-    ])
-    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
-
-    when:
-    def imageDetails = azureImageFinder.byTags(stage, "moderne",
-        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
-
-    then:
-    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
-        managedImageWireShape("canadacentral",
-            "moderne-1746961200000-noble-arm64", baseTags),
-        galleryImageWireShape("canadacentral", "2026.5.1", baseTags),  // older!
-    ])
-    0 * _
-
-    and: "gallery wins on name, not on version -- known limitation, structural fix is imageSource: gallery"
-    imageDetails.size() == 1
-    imageDetails.first().imageName == "moderne-arm64-noble"
-    imageDetails.first().get("version") == "2026.5.1"
-  }
-
-  def "imageSource=gallery sends only galleryImages=true and structurally avoids the mixed-source gap"() {
-    given: "the devaz-shape pipeline pins imageSource to gallery"
-    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
-        account    : "moderne-azure",
-        regions    : ["canadacentral"],
-        imageSource: "gallery",
-    ])
-    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
-
-    when:
-    def imageDetails = azureImageFinder.byTags(stage, "moderne",
-        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
-
-    then: "controller is told to skip managed images entirely; only gallery rows come back"
-    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
-        "tag:moderne_base"   : "true",
-        "tag:moderne_base_os": "ubuntu-arm64-24.04",
-        "managedImages"      : "false",
-        "galleryImages"      : "true",
-    ]) >> Calls.response([
-        galleryImageWireShape("canadacentral", "2026.5.10", baseTags),
-        galleryImageWireShape("canadacentral", "2026.5.8", baseTags),
-    ])
-    0 * _
-
-    and: "the newest gallery version is selected -- no managed image was ever in the running"
-    imageDetails.size() == 1
-    imageDetails.first().get("version") == "2026.5.10"
-  }
-
-  def "imageSource=managed sends only managedImages=true (AWS-parity tenants)"() {
-    given:
-    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
-        account    : "moderne-azure",
-        regions    : ["canadacentral"],
-        imageSource: "managed",
-    ])
-    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
-
-    when:
-    def imageDetails = azureImageFinder.byTags(stage, "moderne",
-        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
-
-    then:
-    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
-        "tag:moderne_base"   : "true",
-        "tag:moderne_base_os": "ubuntu-arm64-24.04",
-        "managedImages"      : "true",
-        "galleryImages"      : "false",
-    ]) >> Calls.response([
-        managedImageWireShape("canadacentral",
-            "moderne-1746874800000-noble-arm64", baseTags),
-        managedImageWireShape("canadacentral",
-            "moderne-1746961200000-noble-arm64", baseTags),
-    ])
-    0 * _
-
-    and: "newest timestamp wins"
-    imageDetails.size() == 1
-    imageDetails.first().imageName == "moderne-1746961200000-noble-arm64"
-  }
-
-  def "imageSource is case-insensitive and accepts 'both' explicitly"() {
-    given:
-    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
-        account    : "moderne-azure",
-        regions    : ["westus"],
-        imageSource: source,
-    ])
-
-    when:
-    azureImageFinder.byTags(stage, "moderne",
-        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
-
-    then:
-    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, { Map m ->
-      m["managedImages"] == expectedManaged && m["galleryImages"] == expectedGallery
-    }) >> Calls.response([])
-
-    where:
-    source    | expectedManaged | expectedGallery
-    "gallery" | "false"         | "true"
-    "GALLERY" | "false"         | "true"
-    "managed" | "true"          | "false"
-    "Managed" | "true"          | "false"
-    "both"    | "true"          | "true"
-    "BOTH"    | "true"          | "true"
-  }
-
-  def "byTags throws when imageSource is unrecognised"() {
-    given:
-    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
-        account    : "moderne-azure",
-        regions    : ["westus"],
-        imageSource: "nonsense",
     ])
 
     when:

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
@@ -123,12 +123,10 @@ class AzureImageFinderSpec extends Specification {
         [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"],
         [])
 
-    then: "clouddriver is asked for gallery images only and returns three out-of-order versions"
+    then: "clouddriver inherits gallery-only from LookupOptions defaults; the finder sends no image-source flags"
     1 * oortService.findImage("azure", "moderne", "moderne-azure", null, [
         "tag:moderne_base"   : "true",
         "tag:moderne_base_os": "ubuntu-arm64-24.04",
-        "managedImages"      : "false",
-        "galleryImages"      : "true",
     ]) >> Calls.response([
         galleryImageWireShape("westus", "2026.5.8", baseTags),
         galleryImageWireShape("westus", "2026.5.10", baseTags),


### PR DESCRIPTION
## Summary

Pinned image selection got flaky on Azure after PR #76 registered the `AzureGalleryImageCachingAgent`. The bug had two layers, both fixed here:

1. **Gallery-version tiebreak in `AzureImageFinder.compareTo`.** Every version of a Shared Image Gallery definition reports the same `imageDefinitionName`, so the dedup-per-region loop in `byTags` was keeping whichever version the cache happened to return first. Added a `version` field on the finder's POJO and a numeric-aware comparator (Azure SIG versions are `MAJOR.MINOR.PATCH` integers).

2. **Mixed managed + gallery in the same region.** When both kinds coexist (canadacentral-shape, where the bake produces a managed image and the replication step publishes a gallery version), the comparator used to fall through to a lex compare on `imageName` — and `"moderne-arm64-noble"` vs `"moderne-1746961200000-noble-arm64"` could go either way depending on the surrounding characters. The comparator now applies a **source preference**: when one image has a non-null `version` (gallery) and the other doesn't (managed), gallery wins. Gallery is the canonical replicated/deploy-time form on Azure.

### Supporting controller changes

- `AzureVMImageLookupController.findImagesByTags` now honors `lookupOptions.managedImages` / `galleryImages`; previously it ignored both flags and always searched both caches.
- `LookupOptions.galleryImages` default flipped to `true`. Shared Image Gallery is the canonical deploy-time form; non-tags `/find` calls (Deck UI image search) now include gallery images by default. Callers that want managed/custom/marketplace-only results can pass `galleryImages=false` explicitly.
- `findImagesByTags` reads the flags directly — the "neither set → both" fallback is gone since the new defaults already express the intent.

`AzureImageFinder` sends `managedImages=true`; `galleryImages` inherits the new default. The controller returns both kinds; the comparator's source preference picks gallery in mixed regions while version-tiebreak handles gallery-only regions.

## Test plan

- [x] `AzureImageFinderSpec` — 20 tests, 0 failures
  - `compareVersions` parametrized (11 rows: numeric semver, null/empty edges, non-numeric fallback)
  - `compareTo` prefers gallery over managed when both are candidates in the same region
  - `compareTo` tiebreaks on `version` when `imageDefinitionName` ties
  - dedup-per-region loop picks the highest version regardless of cache order
  - end-to-end `byTags`: out-of-order gallery versions in `westus`, newest wins; finder sends `managedImages=true`
  - region filter: gallery images in `eastus` filtered out when deploy targets `westus`
  - multi-region: newest version per region
  - empty response → `null`; missing regions → `IllegalArgumentException`
  - mixed managed + gallery in canadacentral: gallery wins (the documented-gap-closure test)
- [x] `AzureVMImageLookupControllerTest` — 13 tests, 0 failures
  - `findImagesByTags` with `managedImages=true` + `galleryImages=false` searches only managed
  - `findImagesByTags` with `galleryImages=true` alone skips the managed cache
  - `findImagesByTags` with neither flag set inherits `LookupOptions` defaults → gallery-only
  - existing `getLookupOptions` helper pins `galleryImages=false` so pre-gallery fixtures keep their assertions
- [ ] Validate against a real devaz `artifactsindexwriter2` execution after deploy.

Pre-existing unrelated test failures in `clouddriver-azure:test` (load balancer / app gateway / server group template specs) reproduce on `main` without these changes and are out of scope.