### PR TITLE
[Azure] Treat managed-image "na" version sentinel as non-gallery in image finder

### DIFF
--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinder.java
@@ -106,10 +106,13 @@ public class AzureImageFinder implements ImageFinder {
     @JsonProperty String region;
     @JsonProperty String osType;
     @JsonProperty String uri;
-    // Set only for Shared Image Gallery results, where all versions of an
-    // image definition share the same `imageName` (= imageDefinitionName) and
-    // the version is what actually distinguishes them. Managed-image results
-    // leave this null and rely on the timestamp embedded in `imageName`.
+    // Carries a real semver only for Shared Image Gallery results, where all
+    // versions of an image definition share the same `imageName` (=
+    // imageDefinitionName) and the version is what distinguishes them.
+    // Managed-image results carry the literal "na" sentinel that the
+    // controller stamps on (AzureVMImageLookupController#buildAzureNamedImage
+    // for managed VM images). Discriminate via `isGalleryVersion`, not raw
+    // null/empty checks.
     @JsonProperty String version;
     @JsonProperty Map<String, Object> attributes;
     @JsonProperty Map<String, String> tags;
@@ -125,7 +128,8 @@ public class AzureImageFinder implements ImageFinder {
               .orElse(null);
 
       return new AzureImageDetails(
-          imageName, region, resourceGroup, osType, uri, version, jenkinsDetails);
+          imageName, region, resourceGroup, osType, uri,
+          isGalleryVersion(version) ? version : null, jenkinsDetails);
     }
 
     @Override
@@ -136,10 +140,10 @@ public class AzureImageFinder implements ImageFinder {
       // would otherwise be unsafe -- a stable gallery imageDefinitionName like
       // "moderne-arm64-noble" can sort either side of a timestamped managed
       // name like "moderne-1746961200000-noble-arm64". Gallery rows expose a
-      // non-null `version`; managed rows don't, which is what we discriminate
-      // on here.
-      boolean thisIsGallery = this.version != null && !this.version.isEmpty();
-      boolean otherIsGallery = other.version != null && !other.version.isEmpty();
+      // real semver in `version`; managed rows carry the controller's "na"
+      // sentinel, which is what we discriminate on here.
+      boolean thisIsGallery = isGalleryVersion(this.version);
+      boolean otherIsGallery = isGalleryVersion(other.version);
       if (thisIsGallery != otherIsGallery) {
         return thisIsGallery ? -1 : 1;
       }
@@ -155,6 +159,13 @@ public class AzureImageFinder implements ImageFinder {
       // by `version` (descending) so the highest version wins.
       return compareVersions(other.version, this.version);
     }
+  }
+
+  // True iff `version` is a real Shared Image Gallery semver. Excludes the
+  // "na" sentinel that AzureVMImageLookupController#buildAzureNamedImage
+  // stamps on managed-image rows, alongside null/empty.
+  static boolean isGalleryVersion(String version) {
+    return version != null && !version.isEmpty() && !"na".equals(version);
   }
 
   // Numeric-aware comparison for Shared Image Gallery versions, which Azure

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/providers/azure/AzureImageFinderSpec.groovy
@@ -49,13 +49,15 @@ class AzureImageFinderSpec extends Specification {
     ]
   }
 
-  // Wire shape for a managed image: timestamped imageName, no `version` field
-  // (Jackson drops keys absent from AzureManagedImage, so omitting `version`
-  // here matches what production responses look like for managed entries).
+  // Wire shape for a managed image: timestamped imageName plus the literal
+  // "na" sentinel that AzureVMImageLookupController#buildAzureNamedImage
+  // stamps on the `version` field for managed entries (it also stamps "na"
+  // on publisher/offer/sku but the finder only inspects version).
   private static Map managedImageWireShape(
       String region, String name, Map<String, String> tags) {
     [
         imageName: name,
+        version  : "na",
         region   : region,
         uri      : "/subscriptions/sub/resourceGroups/rg/providers/" +
                    "Microsoft.Compute/images/${name}".toString(),
@@ -83,17 +85,39 @@ class AzureImageFinderSpec extends Specification {
   }
 
   def "AzureManagedImage compareTo prefers gallery over managed when both candidate in the same region"() {
-    given: "a gallery image (has version) and a managed image (no version), names that would lex either way"
+    given: "a gallery image (has version) and a managed image (version='na' per the controller's wire shape)"
     def gallery = new AzureImageFinder.AzureManagedImage(
         imageName: "moderne-arm64-noble",  // 'a' > '1' on the next char
         version: "2026.5.1",  // intentionally OLDER than the managed bake
         region: "canadacentral")
     def managed = new AzureImageFinder.AzureManagedImage(
         imageName: "moderne-1746961200000-noble-arm64",
-        version: null,
+        version: "na",
         region: "canadacentral")
 
     expect: "gallery sorts first regardless of name lex or relative age"
+    gallery.compareTo(managed) < 0
+    managed.compareTo(gallery) > 0
+  }
+
+  def "AzureManagedImage compareTo prefers gallery even when managed lex-beats gallery on imageName"() {
+    // Source preference must not rely on the imageName lex tiebreak. The
+    // controller stamps version="na" on managed rows, so a naive "is version
+    // non-empty?" discriminator misclassifies managed as gallery, falling
+    // through to a reverse-alpha imageName compare. We pick names here where
+    // that lex compare would pick the WRONG image -- the test then proves
+    // source preference is doing the work, not luck.
+    given: "names where managed sorts AFTER gallery alphabetically (lex would pick managed under reverse-alpha)"
+    def gallery = new AzureImageFinder.AzureManagedImage(
+        imageName: "bake-noble-arm64",  // 'b' < 'z' so gallery lex < managed lex
+        version: "2026.5.1",
+        region: "canadacentral")
+    def managed = new AzureImageFinder.AzureManagedImage(
+        imageName: "zone-1746961200000-noble-arm64",
+        version: "na",  // production sentinel from AzureVMImageLookupController:496
+        region: "canadacentral")
+
+    expect: "gallery still wins on source preference"
     gallery.compareTo(managed) < 0
     managed.compareTo(gallery) > 0
   }
@@ -295,5 +319,35 @@ class AzureImageFinderSpec extends Specification {
     imageDetails.first().imageName == "moderne-arm64-noble"
     imageDetails.first().get("version") == "2026.5.1"
     imageDetails.first().imageId.contains("/galleries/")
+  }
+
+  def "byTags omits version key for managed-only region (controller's 'na' sentinel is sanitized)"() {
+    // Bake regions return only a managed image (the gallery replication hasn't
+    // run yet). The controller stamps version='na' on managed entries; the
+    // finder must not propagate that sentinel into the deploy stage's image
+    // details, where downstream consumers expect either a real semver or no
+    // version key at all (same convention used for uri/imageId on line 200).
+    given:
+    def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "", [
+        account: "moderne-azure",
+        regions: ["canadacentral"],
+    ])
+    def baseTags = [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"]
+
+    when:
+    def imageDetails = azureImageFinder.byTags(stage, "moderne",
+        [moderne_base: "true", moderne_base_os: "ubuntu-arm64-24.04"], [])
+
+    then: "clouddriver returns a managed-only result (bake region, pre-replication)"
+    1 * oortService.findImage("azure", "moderne", "moderne-azure", null, _) >> Calls.response([
+        managedImageWireShape("canadacentral",
+            "moderne-1746961200000-noble-arm64", baseTags),
+    ])
+    0 * _
+
+    and: "managed image is selected, but the 'na' sentinel is not exposed as a version"
+    imageDetails.size() == 1
+    imageDetails.first().imageName == "moderne-1746961200000-noble-arm64"
+    imageDetails.first().get("version") == null
   }
 }


### PR DESCRIPTION
## Summary

- Followup to #89. The gallery-vs-managed discriminator there only checked `version != null && !version.isEmpty()`, but `AzureVMImageLookupController#buildAzureNamedImage` stamps the literal string `"na"` on managed-image rows. That non-empty string slips through the check, which means:

- **Source preference is silently disabled** in mixed-source regions: both rows get flagged "gallery," the `if (thisIsGallery != otherIsGallery)` branch in `compareTo` is skipped, and the comparator falls through to the reverse-alpha `imageName` lex compare that the source-preference branch was specifically designed to bypass. Today's gallery names (`moderne-arm64-noble`) and managed names (`moderne-1746961200000-…`) happen to make that lex compare pick gallery, but only because letters > digits in ASCII. Flip either naming convention and managed wins.
- **The `"na"` sentinel leaks into deploy stages** for managed-only regions (e.g. fresh bake regions pre-replication): `toAzureImageDetails` passes `"na"` straight through to `AzureImageDetails`, which writes `version: "na"` into the result map. Downstream consumers expect either a real semver or no `version` key at all — the same convention `AzureImageDetails` already enforces for `uri`/`imageId` via its `!uri.equals("na")` check on line 200.

- PR #89's tests passed by accident: `managedImageWireShape` omitted the `version` key entirely, so Jackson left the field null in the fixture and the discriminator worked. In production, the field is populated with `"na"`.

## Fix

- New `static boolean isGalleryVersion(String)` helper in `AzureImageFinder` that excludes the `"na"` sentinel alongside null/empty.
- Used in `compareTo` (source-preference discriminator) and in `toAzureImageDetails` (pass `null` instead of `"na"` so the sentinel never reaches `AzureImageDetails`).
- Updated the `version` field doc comment to describe the controller's `"na"` convention so the next reader doesn't trip the same wire-shape mismatch.

## Tests

- `managedImageWireShape` now carries `version: "na"` to match what the controller actually emits, locking the production wire shape into the fixture.
- New unit test `compareTo prefers gallery even when managed lex-beats gallery on imageName`: lex-adversarial names (`bake-noble-arm64` vs `zone-1746961200000-…`) where the imageName lex tiebreak would pick managed. Proves source preference is doing the work, not luck.
- New byTags test `byTags omits version key for managed-only region (controller's 'na' sentinel is sanitized)`: managed-only fixture, asserts `imageDetails.first().get("version") == null`.

Both tests fail on `main` (current `AzureImageFinder`) for exactly the right reasons — the unit test reports `compareTo` returning `+24` (the `'z'-'b'` lex distance) where it should return `-1`, and the byTags test sees `version:na` in the result map.

## Test plan

- [x] `./gradlew :orca:orca-clouddriver:test --tests AzureImageFinderSpec` — 22 tests, 0 failures, 0 errors
- [x] Both new tests fail on `main` for the expected reasons, pass with the fix
- [x] No production wire-format changes in the controller (deliberately out of scope; the `"na"` convention's blast radius across other consumers of `/azure/images/find` is unknown)