### PR TITLE
fix(ecs): resolve :latest ECR artifacts that use short-form references

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
@@ -65,4 +65,11 @@ public class EcsImagesController {
     EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolve(reference);
     return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
   }
+
+  @RequestMapping(value = "/resolveDockerTagByName", method = RequestMethod.GET)
+  public Map<String, String> resolveDockerTagByName(
+      @RequestParam("repository") String repository, @RequestParam("tag") String tag) {
+    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolveByName(repository, tag);
+    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
+  }
 }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
@@ -27,6 +27,8 @@ import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
@@ -40,8 +42,8 @@ import org.springframework.stereotype.Component;
  * digest. "Stable semver" here matches {@code N.N.N} (no pre-release suffix), which lines up with
  * the format that jib publishes for non-SNAPSHOT releases.
  *
- * <p>Throws on no peer match (caller must not silently fall through; that reintroduces the bug
- * this class exists to fix).
+ * <p>Throws on no peer match (caller must not silently fall through; that reintroduces the bug this
+ * class exists to fix).
  */
 @Component
 public class EcrDockerTagResolver {
@@ -71,39 +73,73 @@ public class EcrDockerTagResolver {
     }
 
     AmazonECR ecr = amazonClientProvider.getAmazonEcr(credentials, parsed.region, false);
+    ImageDetail detail = describeImage(ecr, parsed.accountId, parsed.repository, parsed.tag);
+    return resolveFromDetail(detail, reference, parsed.tag);
+  }
 
-    DescribeImagesResult byTag =
-        ecr.describeImages(
-            new DescribeImagesRequest()
-                .withRegistryId(parsed.accountId)
-                .withRepositoryName(parsed.repository)
-                .withImageIds(new ImageIdentifier().withImageTag(parsed.tag)));
-
-    if (byTag.getImageDetails() == null || byTag.getImageDetails().isEmpty()) {
-      throw new NotFoundException(
-          "No ECR image found for tag " + parsed.tag + " in repository " + parsed.repository);
+  /**
+   * Resolves a short-form {@code repository:tag} reference (e.g. {@code
+   * moderne/recipe-worker-arm64:latest}) by scanning all registered ECR credentials until one that
+   * holds the repository is found. The returned {@link ResolveResult#resolvedReference} uses the
+   * same short form so downstream pipeline stages store a pinned short reference rather than a full
+   * URI.
+   */
+  public ResolveResult resolveByName(String repository, String tag) {
+    List<String> tried = new ArrayList<>();
+    for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
+      for (AmazonCredentials.AWSRegion awsRegion : credentials.getRegions()) {
+        String region = awsRegion.getName();
+        try {
+          AmazonECR ecr = amazonClientProvider.getAmazonEcr(credentials, region, false);
+          ImageDetail detail = describeImage(ecr, null, repository, tag);
+          return resolveFromDetail(detail, repository + ":" + tag, tag);
+        } catch (com.amazonaws.services.ecr.model.RepositoryNotFoundException ignored) {
+          tried.add(credentials.getAccountId() + "/" + region);
+        }
+      }
     }
+    throw new NotFoundException(
+        "Repository " + repository + " not found in any registered ECR account; tried: " + tried);
+  }
 
-    ImageDetail detail = byTag.getImageDetails().get(0);
-    String digest = detail.getImageDigest();
+  private static ImageDetail describeImage(
+      AmazonECR ecr, String registryId, String repository, String tag) {
+    DescribeImagesRequest request =
+        new DescribeImagesRequest()
+            .withRepositoryName(repository)
+            .withImageIds(new ImageIdentifier().withImageTag(tag));
+    if (registryId != null) {
+      request.withRegistryId(registryId);
+    }
+    DescribeImagesResult result = ecr.describeImages(request);
+    if (result.getImageDetails() == null || result.getImageDetails().isEmpty()) {
+      throw new NotFoundException(
+          "No ECR image found for tag " + tag + " in repository " + repository);
+    }
+    return result.getImageDetails().get(0);
+  }
+
+  private static ResolveResult resolveFromDetail(
+      ImageDetail detail, String originalReference, String originalTag) {
     List<String> peerTags =
-        Optional.ofNullable(detail.getImageTags()).orElseGet(java.util.Collections::emptyList);
+        Optional.ofNullable(detail.getImageTags()).orElseGet(Collections::emptyList);
 
     Optional<String> resolved =
         peerTags.stream()
-            .filter(t -> !parsed.tag.equals(t))
+            .filter(t -> !originalTag.equals(t))
             .filter(t -> STABLE_SEMVER.matcher(t).matches())
             .max(EcrDockerTagResolver::compareSemver);
 
     if (resolved.isPresent()) {
-      return new ResolveResult(resolved.get(), rewriteReference(reference, parsed.tag, resolved.get()));
+      return new ResolveResult(
+          resolved.get(), rewriteReference(originalReference, originalTag, resolved.get()));
     }
 
     throw new NotFoundException(
         "ECR image "
-            + reference
+            + originalReference
             + " (digest "
-            + digest
+            + detail.getImageDigest()
             + ") has no peer tag matching stable semver "
             + STABLE_SEMVER.pattern()
             + "; peer tags were "
@@ -114,8 +150,7 @@ public class EcrDockerTagResolver {
     for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
       if (credentials.getAccountId().equals(accountId)
           && (credentials.getRegions().isEmpty()
-              || credentials.getRegions().stream()
-                  .anyMatch(r -> r.getName().equals(region)))) {
+              || credentials.getRegions().stream().anyMatch(r -> r.getName().equals(region)))) {
         return credentials;
       }
     }
@@ -180,8 +215,7 @@ public class EcrDockerTagResolver {
     static EcrReference parse(String reference) {
       Matcher m = PATTERN.matcher(reference);
       if (!m.matches()) {
-        throw new IllegalArgumentException(
-            "Reference is not a valid tagged ECR URI: " + reference);
+        throw new IllegalArgumentException("Reference is not a valid tagged ECR URI: " + reference);
       }
       return new EcrReference(m.group(1), m.group(2), m.group(3), m.group(4));
     }

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
@@ -25,7 +25,6 @@ import com.amazonaws.services.ecr.model.DescribeImagesResult;
 import com.amazonaws.services.ecr.model.ImageDetail;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
-import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
@@ -53,7 +52,9 @@ final class EcrDockerTagResolverTest {
     org.mockito.Mockito.when(credentialsRepository.getAll()).thenReturn(Set.of(creds));
     org.mockito.Mockito.when(
             amazonClientProvider.getAmazonEcr(
-                ArgumentMatchers.any(), ArgumentMatchers.eq("us-west-2"), ArgumentMatchers.eq(false)))
+                ArgumentMatchers.any(),
+                ArgumentMatchers.eq("us-west-2"),
+                ArgumentMatchers.eq(false)))
         .thenReturn(ecr);
 
     target = new EcrDockerTagResolver(amazonClientProvider, credentialsRepository);
@@ -121,6 +122,36 @@ final class EcrDockerTagResolverTest {
         .hasMessageContaining("not a valid tagged ECR URI");
   }
 
+  // resolveByName — short-form references as stored by moderne-saas pipelines
+
+  @Test
+  void resolveByName_picksHighestStableSemver() {
+    // Exact shape stored in metapipelines.libsonnet defaultArtifact: "moderne/repo:latest"
+    stubDescribeImages(List.of("latest", "0.147.3", "0.146.0", "0.147.3-rc1"));
+    EcrDockerTagResolver.ResolveResult result =
+        target.resolveByName("moderne/recipe-worker-arm64", "latest");
+    assertThat(result.resolvedTag).isEqualTo("0.147.3");
+    // resolvedReference preserves the short form so repave stores a pinned short reference
+    assertThat(result.resolvedReference).isEqualTo("moderne/recipe-worker-arm64:0.147.3");
+  }
+
+  @Test
+  void resolveByName_noStableSemverPeer_throws() {
+    stubDescribeImages(List.of("latest", "0.147.3-SNAPSHOT-20260427-181523"));
+    assertThatThrownBy(() -> target.resolveByName("moderne/recipe-worker-arm64", "latest"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("no peer tag matching stable semver");
+  }
+
+  @Test
+  void resolveByName_repositoryNotFound_throws() {
+    org.mockito.Mockito.when(ecr.describeImages(ArgumentMatchers.any(DescribeImagesRequest.class)))
+        .thenThrow(new com.amazonaws.services.ecr.model.RepositoryNotFoundException("not found"));
+    assertThatThrownBy(() -> target.resolveByName("moderne/nonexistent", "latest"))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("not found in any registered ECR account");
+  }
+
   @Test
   void parsesReferenceComponents() {
     EcrDockerTagResolver.EcrReference parsed =
@@ -136,9 +167,7 @@ final class EcrDockerTagResolverTest {
     DescribeImagesResult describe =
         new DescribeImagesResult()
             .withImageDetails(
-                new ImageDetail()
-                    .withImageDigest("sha256:abc123")
-                    .withImageTags(tags));
+                new ImageDetail().withImageDigest("sha256:abc123").withImageTags(tags));
     org.mockito.Mockito.when(ecr.describeImages(ArgumentMatchers.any(DescribeImagesRequest.class)))
         .thenReturn(describe);
   }
@@ -146,7 +175,8 @@ final class EcrDockerTagResolverTest {
   private static NetflixECSCredentials stubCredentials(String accountId, String region) {
     NetflixECSCredentials credentials = org.mockito.Mockito.mock(NetflixECSCredentials.class);
     org.mockito.Mockito.when(credentials.getAccountId()).thenReturn(accountId);
-    AmazonCredentials.AWSRegion awsRegion = org.mockito.Mockito.mock(AmazonCredentials.AWSRegion.class);
+    AmazonCredentials.AWSRegion awsRegion =
+        org.mockito.Mockito.mock(AmazonCredentials.AWSRegion.class);
     org.mockito.Mockito.when(awsRegion.getName()).thenReturn(region);
     org.mockito.Mockito.when(credentials.getRegions()).thenReturn(List.of(awsRegion));
     return (NetflixECSCredentials) credentials;

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
@@ -48,7 +48,7 @@ final class EcrDockerTagResolverTest {
     credentialsRepository = org.mockito.Mockito.mock(CredentialsRepository.class);
     ecr = org.mockito.Mockito.mock(AmazonECR.class);
 
-    NetflixECSCredentials creds = stubCredentials("297794628946", "us-west-2");
+    NetflixECSCredentials creds = stubCredentials("123456789012", "us-west-2");
     org.mockito.Mockito.when(credentialsRepository.getAll()).thenReturn(Set.of(creds));
     org.mockito.Mockito.when(
             amazonClientProvider.getAmazonEcr(
@@ -65,11 +65,11 @@ final class EcrDockerTagResolverTest {
     stubDescribeImages(List.of("latest", "0.147.3", "0.146.0", "0.147.3-rc1"));
     EcrDockerTagResolver.ResolveResult result =
         target.resolve(
-            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+            "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
     assertThat(result.resolvedTag).isEqualTo("0.147.3");
     assertThat(result.resolvedReference)
         .isEqualTo(
-            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3");
+            "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3");
   }
 
   @Test
@@ -78,7 +78,7 @@ final class EcrDockerTagResolverTest {
     assertThatThrownBy(
             () ->
                 target.resolve(
-                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+                    "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("no peer tag matching stable semver");
   }
@@ -89,7 +89,7 @@ final class EcrDockerTagResolverTest {
     assertThatThrownBy(
             () ->
                 target.resolve(
-                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+                    "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
         .isInstanceOf(NotFoundException.class);
   }
 
@@ -100,7 +100,7 @@ final class EcrDockerTagResolverTest {
     assertThatThrownBy(
             () ->
                 target.resolve(
-                    "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
+                    "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest"))
         .isInstanceOf(NotFoundException.class)
         .hasMessageContaining("No ECR image found for tag latest");
   }
@@ -111,7 +111,7 @@ final class EcrDockerTagResolverTest {
     stubDescribeImages(List.of("latest", "0.9.9", "0.10.0"));
     EcrDockerTagResolver.ResolveResult result =
         target.resolve(
-            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+            "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
     assertThat(result.resolvedTag).isEqualTo("0.10.0");
   }
 
@@ -156,8 +156,8 @@ final class EcrDockerTagResolverTest {
   void parsesReferenceComponents() {
     EcrDockerTagResolver.EcrReference parsed =
         EcrDockerTagResolver.EcrReference.parse(
-            "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
-    assertThat(parsed.accountId).isEqualTo("297794628946");
+            "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest");
+    assertThat(parsed.accountId).isEqualTo("123456789012");
     assertThat(parsed.region).isEqualTo("us-west-2");
     assertThat(parsed.repository).isEqualTo("moderne/recipe-worker-arm64");
     assertThat(parsed.tag).isEqualTo("latest");

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/DelegatingOortService.java
@@ -171,6 +171,11 @@ public class DelegatingOortService extends DelegatingClouddriverService<OortServ
   }
 
   @Override
+  public Call<Map<String, String>> resolveDockerTagByName(String repository, String tag) {
+    return getService().resolveDockerTagByName(repository, tag);
+  }
+
+  @Override
   public Call<List<Map<String, Object>>> getEntityTags(
       String cloudProvider, String entityType, String entityId, String account, String region) {
     return getService().getEntityTags(cloudProvider, entityType, entityId, account, region);

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
@@ -26,14 +26,22 @@ import org.springframework.stereotype.Component;
 
 /**
  * Resolves docker/image artifacts whose reference points at an ECR registry by delegating to
- * clouddriver's {@code /ecs/images/resolveDockerTag} endpoint, which performs the digest→tag
- * lookup using the existing AWS credentials repository.
+ * clouddriver's {@code /ecs/images/resolveDockerTag} (full URI) or {@code
+ * /ecs/images/resolveDockerTagByName} (short {@code org/repo:tag} form) endpoints, which perform
+ * the digest→semver-tag lookup using the existing AWS credentials repository.
+ *
+ * <p>Pipeline artifacts in moderne-saas use short-form references ({@code
+ * moderne/recipe-worker-arm64:latest}) without the ECR registry hostname. Both forms are accepted
+ * so that the resolver fires regardless of which form the pipeline stores.
  */
 @Component
 public class EcrDockerLatestResolver implements DockerLatestResolver {
-  private static final Pattern ECR_REFERENCE =
-      Pattern.compile(
-          "^(?:https?://)?\\d{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/.+:.+$");
+  // Full ECR URI: 297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/repo:tag
+  private static final Pattern ECR_FULL_REFERENCE =
+      Pattern.compile("^(?:https?://)?\\d{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/.+:.+$");
+
+  // Short ECR org reference as stored by moderne-saas pipelines: moderne/repo:tag
+  private static final Pattern ECR_SHORT_REFERENCE = Pattern.compile("^moderne/[^:]+:.+$");
 
   private final OortService oortService;
 
@@ -45,13 +53,26 @@ public class EcrDockerLatestResolver implements DockerLatestResolver {
   @Override
   public boolean handles(Artifact artifact) {
     String reference = artifact.getReference();
-    return reference != null && ECR_REFERENCE.matcher(reference).matches();
+    if (reference == null) {
+      return false;
+    }
+    return ECR_FULL_REFERENCE.matcher(reference).matches()
+        || ECR_SHORT_REFERENCE.matcher(reference).matches();
   }
 
   @Override
   public Artifact canonicalize(Artifact artifact) {
-    Map<String, String> response =
-        Retrofit2SyncCall.execute(oortService.resolveDockerTag(artifact.getReference()));
+    String reference = artifact.getReference();
+    Map<String, String> response;
+    if (ECR_SHORT_REFERENCE.matcher(reference).matches()) {
+      // Split "moderne/repo:tag" into repository and tag for the by-name endpoint.
+      int colon = reference.lastIndexOf(':');
+      String repository = reference.substring(0, colon);
+      String tag = reference.substring(colon + 1);
+      response = Retrofit2SyncCall.execute(oortService.resolveDockerTagByName(repository, tag));
+    } else {
+      response = Retrofit2SyncCall.execute(oortService.resolveDockerTag(reference));
+    }
     String resolvedTag = response.get("resolvedTag");
     String resolvedReference = response.get("reference");
     if (resolvedTag == null || resolvedReference == null) {

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
@@ -36,7 +36,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class EcrDockerLatestResolver implements DockerLatestResolver {
-  // Full ECR URI: 297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/repo:tag
+  // Full ECR URI: 123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/repo:tag
   private static final Pattern ECR_FULL_REFERENCE =
       Pattern.compile("^(?:https?://)?\\d{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/.+:.+$");
 

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -175,6 +175,10 @@ public interface OortService {
   @GET("ecs/images/resolveDockerTag")
   Call<Map<String, String>> resolveDockerTag(@Query("reference") String reference);
 
+  @GET("ecs/images/resolveDockerTagByName")
+  Call<Map<String, String>> resolveDockerTagByName(
+      @Query("repository") String repository, @Query("tag") String tag);
+
   @GET("tags")
   Call<List<Map<String, Object>>> getEntityTags(
       @Query("cloudProvider") String cloudProvider,

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
@@ -34,10 +34,18 @@ import retrofit2.mock.Calls;
 
 final class EcrDockerLatestResolverTest {
 
-  private static final String LATEST_REF =
+  // Full ECR URI form
+  private static final String LATEST_REF_FULL =
       "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
-  private static final String RESOLVED_REF =
+  private static final String RESOLVED_REF_FULL =
       "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
+
+  // Short form as stored by metapipelines.libsonnet defaultArtifact — what actually flows
+  // through the repave-allstate execution (confirmed from live Spinnaker execution data).
+  // Artifact shape: {type:"docker/image", name:"moderne/audit-reader-arm64",
+  //                  reference:"moderne/audit-reader-arm64:latest", version:"latest"}
+  private static final String LATEST_REF_SHORT = "moderne/audit-reader-arm64:latest";
+  private static final String RESOLVED_REF_SHORT = "moderne/audit-reader-arm64:0.147.3";
 
   private OortService oortService;
   private EcrDockerLatestResolver target;
@@ -48,10 +56,25 @@ final class EcrDockerLatestResolverTest {
     target = new EcrDockerLatestResolver(oortService);
   }
 
+  // --- handles() ---
+
   @Test
-  void handles_ecrReference() {
+  void handles_fullEcrReference() {
+    Artifact ecr = Artifact.builder().type("docker/image").reference(LATEST_REF_FULL).build();
+    assertThat(target.handles(ecr)).isTrue();
+  }
+
+  @Test
+  void handles_shortEcrReference_asStoredByMetapipelines() {
+    // This is the exact artifact shape from repave-allstate execution that was
+    // passing through unresolved before the fix.
     Artifact ecr =
-        Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+        Artifact.builder()
+            .type("docker/image")
+            .name("moderne/audit-reader-arm64")
+            .version("latest")
+            .reference(LATEST_REF_SHORT)
+            .build();
     assertThat(target.handles(ecr)).isTrue();
   }
 
@@ -68,31 +91,58 @@ final class EcrDockerLatestResolverTest {
     assertThat(target.handles(noRef)).isFalse();
   }
 
+  // --- canonicalize() with full ECR URI ---
+
   @Test
-  void canonicalize_callsOortServiceAndRewritesArtifact() {
+  void canonicalize_fullUri_callsResolveDockerTag() {
     Call<Map<String, String>> call =
-        Calls.response(Map.of("resolvedTag", "0.147.3", "reference", RESOLVED_REF));
-    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+        Calls.response(Map.of("resolvedTag", "0.147.3", "reference", RESOLVED_REF_FULL));
+    when(oortService.resolveDockerTag(eq(LATEST_REF_FULL))).thenReturn(call);
 
     Artifact input =
         Artifact.builder()
             .type("docker/image")
             .name("moderne/recipe-worker-arm64")
             .version("latest")
-            .reference(LATEST_REF)
+            .reference(LATEST_REF_FULL)
             .build();
     Artifact result = target.canonicalize(input);
     assertThat(result.getVersion()).isEqualTo("0.147.3");
-    assertThat(result.getReference()).isEqualTo(RESOLVED_REF);
+    assertThat(result.getReference()).isEqualTo(RESOLVED_REF_FULL);
     assertThat(result.getName()).isEqualTo("moderne/recipe-worker-arm64");
+  }
+
+  // --- canonicalize() with short reference (the actual bug scenario) ---
+
+  @Test
+  void canonicalize_shortRef_callsResolveDockerTagByName_andPinsVersion() {
+    // Reproduces the exact failure: artifact from repave-allstate find stage with
+    // reference="moderne/audit-reader-arm64:latest", version="latest".
+    // After fix, canonicalize() must call resolveDockerTagByName and rewrite the artifact.
+    Call<Map<String, String>> call =
+        Calls.response(Map.of("resolvedTag", "0.147.3", "reference", RESOLVED_REF_SHORT));
+    when(oortService.resolveDockerTagByName(eq("moderne/audit-reader-arm64"), eq("latest")))
+        .thenReturn(call);
+
+    Artifact input =
+        Artifact.builder()
+            .type("docker/image")
+            .name("moderne/audit-reader-arm64")
+            .version("latest")
+            .reference(LATEST_REF_SHORT)
+            .build();
+    Artifact result = target.canonicalize(input);
+    assertThat(result.getVersion()).isEqualTo("0.147.3");
+    assertThat(result.getReference()).isEqualTo(RESOLVED_REF_SHORT);
+    assertThat(result.getName()).isEqualTo("moderne/audit-reader-arm64");
   }
 
   @Test
   void canonicalize_oortReturnsIncompleteResponse_throws() {
     Call<Map<String, String>> call = Calls.response(Map.of("resolvedTag", "0.147.3"));
-    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+    when(oortService.resolveDockerTag(eq(LATEST_REF_FULL))).thenReturn(call);
 
-    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF_FULL).build();
     assertThatThrownBy(() -> target.canonicalize(input))
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("incomplete response");
@@ -102,12 +152,10 @@ final class EcrDockerLatestResolverTest {
   void canonicalize_oortPropagatesErrorAsRuntime() {
     Call<Map<String, String>> call =
         Calls.response(
-            Response.error(
-                404,
-                ResponseBody.create("not found", MediaType.parse("text/plain"))));
-    when(oortService.resolveDockerTag(eq(LATEST_REF))).thenReturn(call);
+            Response.error(404, ResponseBody.create("not found", MediaType.parse("text/plain"))));
+    when(oortService.resolveDockerTag(eq(LATEST_REF_FULL))).thenReturn(call);
 
-    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF).build();
+    Artifact input = Artifact.builder().type("docker/image").reference(LATEST_REF_FULL).build();
     assertThatThrownBy(() -> target.canonicalize(input)).isInstanceOf(RuntimeException.class);
   }
 }

--- a/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
+++ b/orca/orca-clouddriver/src/test/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolverTest.java
@@ -36,9 +36,9 @@ final class EcrDockerLatestResolverTest {
 
   // Full ECR URI form
   private static final String LATEST_REF_FULL =
-      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
+      "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
   private static final String RESOLVED_REF_FULL =
-      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
+      "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
 
   // Short form as stored by metapipelines.libsonnet defaultArtifact — what actually flows
   // through the repave-allstate execution (confirmed from live Spinnaker execution data).

--- a/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionServiceTest.java
+++ b/orca/orca-core/src/test/java/com/netflix/spinnaker/orca/pipeline/util/DockerLatestResolutionServiceTest.java
@@ -28,9 +28,9 @@ import org.junit.jupiter.api.Test;
 final class DockerLatestResolutionServiceTest {
 
   private static final String LATEST_REF =
-      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
+      "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:latest";
   private static final String RESOLVED_REF =
-      "297794628946.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
+      "123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/recipe-worker-arm64:0.147.3";
 
   private static Artifact dockerLatest() {
     return Artifact.builder()


### PR DESCRIPTION
## Problem

Moderne-saas repave pipelines (e.g. `repave-allstate`) store artifact
references in short form — `moderne/repo:latest` — without the ECR registry
hostname. This is how `metapipelines.libsonnet`'s `findLastDeployedImage()`
builds its `defaultArtifact`:

```
reference: moderne/audit-reader-arm64:latest   ← short form
version:   latest
type:      docker/image
```

The existing `EcrDockerLatestResolver.handles()` regex required a full ECR
URI (`297794628946.dkr.ecr.us-west-2.amazonaws.com/...`), so it returned
`false` for every artifact that actually flows through the pipeline.
`DockerLatestResolutionService` skipped resolution and `:latest` passed
through unchanged, showing up in the status dashboard as the deployed version.

Confirmed via live repave-allstate execution data
(01KRY6108PPGV1R9EBVEF7B8Q7, ran 2026-05-18).

## Fix

- **`EcrDockerLatestResolver`** — add `ECR_SHORT_REFERENCE` pattern (`^moderne/[^:]+:.+$`) so `handles()` fires on short-form references too; route them through a new `resolveDockerTagByName` call that passes repository and tag separately
- **`EcrDockerTagResolver`** — extract `describeImage()` and `resolveFromDetail()` helpers, add `resolveByName(repository, tag)` that scans all registered `NetflixECSCredentials` until it finds the repository, returns a pinned short-form reference (`moderne/repo:0.147.3`)
- **`EcsImagesController`** — add `GET /ecs/images/resolveDockerTagByName?repository=&tag=` endpoint
- **`OortService` / `DelegatingOortService`** — add `resolveDockerTagByName` Retrofit method + delegation

## Tests

Unit tests added/extended with data drawn from live pipeline execution:

- `EcrDockerLatestResolverTest` — covers `handles()` for both full and short references, `canonicalize()` routing for both paths, error cases
- `EcrDockerTagResolverTest` — covers `resolveByName()` semver selection, pre-release exclusion, credential scanning, `RepositoryNotFoundException` propagation