### PR TITLE
fix(ecs): use AWS credentials repo and add 404 fallback for ECR latest resolution

### DIFF
--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolver.java
@@ -24,7 +24,6 @@ import com.amazonaws.services.ecr.model.ImageIdentifier;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.ArrayList;
@@ -50,12 +49,12 @@ public class EcrDockerTagResolver {
   private static final Pattern STABLE_SEMVER = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
 
   private final AmazonClientProvider amazonClientProvider;
-  private final CredentialsRepository<NetflixECSCredentials> credentialsRepository;
+  private final CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
 
   @Autowired
   public EcrDockerTagResolver(
       AmazonClientProvider amazonClientProvider,
-      CredentialsRepository<NetflixECSCredentials> credentialsRepository) {
+      CredentialsRepository<NetflixAmazonCredentials> credentialsRepository) {
     this.amazonClientProvider = amazonClientProvider;
     this.credentialsRepository = credentialsRepository;
   }
@@ -86,7 +85,7 @@ public class EcrDockerTagResolver {
    */
   public ResolveResult resolveByName(String repository, String tag) {
     List<String> tried = new ArrayList<>();
-    for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
+    for (NetflixAmazonCredentials credentials : credentialsRepository.getAll()) {
       for (AmazonCredentials.AWSRegion awsRegion : credentials.getRegions()) {
         String region = awsRegion.getName();
         try {
@@ -147,7 +146,7 @@ public class EcrDockerTagResolver {
   }
 
   private NetflixAmazonCredentials lookupCredentials(String accountId, String region) {
-    for (NetflixECSCredentials credentials : credentialsRepository.getAll()) {
+    for (NetflixAmazonCredentials credentials : credentialsRepository.getAll()) {
       if (credentials.getAccountId().equals(accountId)
           && (credentials.getRegions().isEmpty()
               || credentials.getRegions().stream().anyMatch(r -> r.getName().equals(region)))) {

--- a/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
+++ b/clouddriver/clouddriver-ecs/src/test/java/com/netflix/spinnaker/clouddriver/ecs/provider/view/EcrDockerTagResolverTest.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.ecr.model.DescribeImagesResult;
 import com.amazonaws.services.ecr.model.ImageDetail;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
+import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
 import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
@@ -37,7 +38,7 @@ import org.mockito.ArgumentMatchers;
 final class EcrDockerTagResolverTest {
 
   private AmazonClientProvider amazonClientProvider;
-  private CredentialsRepository<NetflixECSCredentials> credentialsRepository;
+  private CredentialsRepository<NetflixAmazonCredentials> credentialsRepository;
   private AmazonECR ecr;
   private EcrDockerTagResolver target;
 

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
@@ -18,9 +18,12 @@ package com.netflix.spinnaker.orca.clouddriver;
 
 import com.netflix.spinnaker.kork.artifacts.model.Artifact;
 import com.netflix.spinnaker.kork.retrofit.Retrofit2SyncCall;
+import com.netflix.spinnaker.kork.retrofit.exceptions.SpinnakerHttpException;
 import com.netflix.spinnaker.orca.pipeline.util.DockerLatestResolver;
 import java.util.Map;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -36,6 +39,7 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class EcrDockerLatestResolver implements DockerLatestResolver {
+  private static final Logger log = LoggerFactory.getLogger(EcrDockerLatestResolver.class);
   // Full ECR URI: 123456789012.dkr.ecr.us-west-2.amazonaws.com/moderne/repo:tag
   private static final Pattern ECR_FULL_REFERENCE =
       Pattern.compile("^(?:https?://)?\\d{12}\\.dkr\\.ecr\\.[a-z0-9-]+\\.amazonaws\\.com/.+:.+$");
@@ -69,7 +73,17 @@ public class EcrDockerLatestResolver implements DockerLatestResolver {
       int colon = reference.lastIndexOf(':');
       String repository = reference.substring(0, colon);
       String tag = reference.substring(colon + 1);
-      response = Retrofit2SyncCall.execute(oortService.resolveDockerTagByName(repository, tag));
+      try {
+        response = Retrofit2SyncCall.execute(oortService.resolveDockerTagByName(repository, tag));
+      } catch (SpinnakerHttpException e) {
+        if (e.getResponseCode() == 404) {
+          log.debug(
+              "clouddriver resolveDockerTagByName endpoint not available (404); passing artifact through unresolved: {}",
+              reference);
+          return artifact;
+        }
+        throw e;
+      }
     } else {
       response = Retrofit2SyncCall.execute(oortService.resolveDockerTag(reference));
     }


### PR DESCRIPTION
## Summary

- Follow-up to #92 — two critical fixes discovered after the initial merge.

**Fix 1: Wrong credential repository (clouddriver)**

`EcrDockerTagResolver` was injecting `CredentialsRepository<NetflixECSCredentials>`, which is empty in Moderne's clouddriver because we deploy to EC2 ASGs, not ECS tasks. This caused `resolveByName` (and therefore `resolveDockerTagByName`) to always throw `NotFoundException("not found in any registered ECR account; tried: []")`, which clouddriver mapped to HTTP 404. Switching to `CredentialsRepository<NetflixAmazonCredentials>` covers all registered AWS accounts — `NetflixECSCredentials` extends it, so any ECS accounts still work.

**Fix 2: 404 fallback in orca (deployment safety net)**

`EcrDockerLatestResolver.canonicalize()` now catches `SpinnakerHttpException` with status 404 on the `resolveDockerTagByName` call and returns the original artifact unchanged rather than propagating. Without this, any 404 from clouddriver (whether from the endpoint not existing or the credential issue) causes `findArtifactFromExecution` stages to fail with STOPPED, making the pipeline TERMINAL. This was already observed live in repave-allstate.

## Root cause

- After #92 was deployed, repave-allstate went TERMINAL: every `findArtifactFromExecution` stage failed because orca called `GET /ecs/images/resolveDockerTagByName` but clouddriver had no ECS credentials to scan, so it returned 404. Orca propagated the exception rather than passing through the artifact.

## Test plan
- [ ] `EcrDockerTagResolverTest` — updated to use `CredentialsRepository<NetflixAmazonCredentials>` mock
- [ ] Verify repave-allstate resumes after clouddriver is redeployed with this fix