### PR TITLE
fix(aws): move ECR resolver out of ECS module so it loads without ECS accounts

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/controllers/EcrImagesController.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/controllers/EcrImagesController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Moderne, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.aws.controllers;
+
+import com.netflix.spinnaker.clouddriver.aws.provider.view.EcrDockerTagResolver;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes the ECR digest→semver-tag lookup over HTTP. Lives in {@code clouddriver-aws} so it loads
+ * whenever AWS is enabled — independent of the ECS module, which is only loaded when ECS accounts
+ * are configured.
+ */
+@RestController
+@RequestMapping("/ecr/images")
+public class EcrImagesController {
+  private final EcrDockerTagResolver ecrDockerTagResolver;
+
+  @Autowired
+  public EcrImagesController(EcrDockerTagResolver ecrDockerTagResolver) {
+    this.ecrDockerTagResolver = ecrDockerTagResolver;
+  }
+
+  @RequestMapping(value = "/resolveDockerTag", method = RequestMethod.GET)
+  public Map<String, String> resolveDockerTag(@RequestParam("reference") String reference) {
+    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolve(reference);
+    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
+  }
+
+  @RequestMapping(value = "/resolveDockerTagByName", method = RequestMethod.GET)
+  public Map<String, String> resolveDockerTagByName(
+      @RequestParam("repository") String repository, @RequestParam("tag") String tag) {
+    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolveByName(repository, tag);
+    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
+  }
+}

--- a/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/view/EcrDockerTagResolver.java
+++ b/clouddriver/clouddriver-aws/src/main/java/com/netflix/spinnaker/clouddriver/aws/provider/view/EcrDockerTagResolver.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.ecs.provider.view;
+package com.netflix.spinnaker.clouddriver.aws.provider.view;
 
 import com.amazonaws.services.ecr.AmazonECR;
 import com.amazonaws.services.ecr.model.DescribeImagesRequest;

--- a/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/view/EcrDockerTagResolverTest.java
+++ b/clouddriver/clouddriver-aws/src/test/java/com/netflix/spinnaker/clouddriver/aws/provider/view/EcrDockerTagResolverTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.netflix.spinnaker.clouddriver.ecs.provider.view;
+package com.netflix.spinnaker.clouddriver.aws.provider.view;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -26,7 +26,6 @@ import com.amazonaws.services.ecr.model.ImageDetail;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonClientProvider;
 import com.netflix.spinnaker.clouddriver.aws.security.AmazonCredentials;
 import com.netflix.spinnaker.clouddriver.aws.security.NetflixAmazonCredentials;
-import com.netflix.spinnaker.clouddriver.ecs.security.NetflixECSCredentials;
 import com.netflix.spinnaker.credentials.CredentialsRepository;
 import com.netflix.spinnaker.kork.web.exceptions.NotFoundException;
 import java.util.List;
@@ -49,7 +48,7 @@ final class EcrDockerTagResolverTest {
     credentialsRepository = org.mockito.Mockito.mock(CredentialsRepository.class);
     ecr = org.mockito.Mockito.mock(AmazonECR.class);
 
-    NetflixECSCredentials creds = stubCredentials("123456789012", "us-west-2");
+    NetflixAmazonCredentials creds = stubCredentials("123456789012", "us-west-2");
     org.mockito.Mockito.when(credentialsRepository.getAll()).thenReturn(Set.of(creds));
     org.mockito.Mockito.when(
             amazonClientProvider.getAmazonEcr(
@@ -173,13 +172,13 @@ final class EcrDockerTagResolverTest {
         .thenReturn(describe);
   }
 
-  private static NetflixECSCredentials stubCredentials(String accountId, String region) {
-    NetflixECSCredentials credentials = org.mockito.Mockito.mock(NetflixECSCredentials.class);
+  private static NetflixAmazonCredentials stubCredentials(String accountId, String region) {
+    NetflixAmazonCredentials credentials = org.mockito.Mockito.mock(NetflixAmazonCredentials.class);
     org.mockito.Mockito.when(credentials.getAccountId()).thenReturn(accountId);
     AmazonCredentials.AWSRegion awsRegion =
         org.mockito.Mockito.mock(AmazonCredentials.AWSRegion.class);
     org.mockito.Mockito.when(awsRegion.getName()).thenReturn(region);
     org.mockito.Mockito.when(credentials.getRegions()).thenReturn(List.of(awsRegion));
-    return (NetflixECSCredentials) credentials;
+    return credentials;
   }
 }

--- a/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
+++ b/clouddriver/clouddriver-ecs/src/main/java/com/netflix/spinnaker/clouddriver/ecs/controllers/EcsImagesController.java
@@ -17,11 +17,9 @@
 package com.netflix.spinnaker.clouddriver.ecs.controllers;
 
 import com.netflix.spinnaker.clouddriver.ecs.model.EcsDockerImage;
-import com.netflix.spinnaker.clouddriver.ecs.provider.view.EcrDockerTagResolver;
 import com.netflix.spinnaker.clouddriver.ecs.provider.view.ImageRepositoryProvider;
 import jakarta.servlet.http.HttpServletRequest;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,14 +31,10 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/ecs/images")
 public class EcsImagesController {
   private final List<ImageRepositoryProvider> imageRepositoryProviders;
-  private final EcrDockerTagResolver ecrDockerTagResolver;
 
   @Autowired
-  public EcsImagesController(
-      List<ImageRepositoryProvider> imageRepositoryProviders,
-      EcrDockerTagResolver ecrDockerTagResolver) {
+  public EcsImagesController(List<ImageRepositoryProvider> imageRepositoryProviders) {
     this.imageRepositoryProviders = imageRepositoryProviders;
-    this.ecrDockerTagResolver = ecrDockerTagResolver;
   }
 
   @RequestMapping(value = "/find", method = RequestMethod.GET)
@@ -58,18 +52,5 @@ public class EcsImagesController {
                 .map(ImageRepositoryProvider::getRepositoryName)
                 .collect(Collectors.joining(", "))
             + ".");
-  }
-
-  @RequestMapping(value = "/resolveDockerTag", method = RequestMethod.GET)
-  public Map<String, String> resolveDockerTag(@RequestParam("reference") String reference) {
-    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolve(reference);
-    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
-  }
-
-  @RequestMapping(value = "/resolveDockerTagByName", method = RequestMethod.GET)
-  public Map<String, String> resolveDockerTagByName(
-      @RequestParam("repository") String repository, @RequestParam("tag") String tag) {
-    EcrDockerTagResolver.ResolveResult result = ecrDockerTagResolver.resolveByName(repository, tag);
-    return Map.of("resolvedTag", result.resolvedTag, "reference", result.resolvedReference);
   }
 }

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/EcrDockerLatestResolver.java
@@ -29,8 +29,8 @@ import org.springframework.stereotype.Component;
 
 /**
  * Resolves docker/image artifacts whose reference points at an ECR registry by delegating to
- * clouddriver's {@code /ecs/images/resolveDockerTag} (full URI) or {@code
- * /ecs/images/resolveDockerTagByName} (short {@code org/repo:tag} form) endpoints, which perform
+ * clouddriver's {@code /ecr/images/resolveDockerTag} (full URI) or {@code
+ * /ecr/images/resolveDockerTagByName} (short {@code org/repo:tag} form) endpoints, which perform
  * the digest→semver-tag lookup using the existing AWS credentials repository.
  *
  * <p>Pipeline artifacts in moderne-saas use short-form references ({@code

--- a/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
+++ b/orca/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/OortService.java
@@ -172,10 +172,10 @@ public interface OortService {
    * including the registry, repository, and current tag. The response carries the resolved tag and
    * a fully-qualified reference with that tag substituted in.
    */
-  @GET("ecs/images/resolveDockerTag")
+  @GET("ecr/images/resolveDockerTag")
   Call<Map<String, String>> resolveDockerTag(@Query("reference") String reference);
 
-  @GET("ecs/images/resolveDockerTagByName")
+  @GET("ecr/images/resolveDockerTagByName")
   Call<Map<String, String>> resolveDockerTagByName(
       @Query("repository") String repository, @Query("tag") String tag);
 


### PR DESCRIPTION
## Summary

- Follow-up to #92 and #93 — diagnosed live on the spinnaker-labs box.

The ECR digest→semver-tag lookup was housed in `clouddriver-ecs` (`EcsImagesController`, `EcrDockerTagResolver`), but the entire ECS Spring module only activates when ECS-type accounts are configured. Moderne deploys to EC2 ASGs and has zero ECS accounts (only `moderne-aws` of type `aws`), so the module's `@Configuration` beans never load. The `EcsImagesController` is in the jar but never gets registered, so `/ecs/images/resolveDockerTagByName` returns Spring's default 404 (`No message available`) regardless of how the resolver code is written.

Verified directly on the running clouddriver:
- `curl http://localhost:7002/ecs/images/resolveDockerTagByName?...` → `404 {error:Not Found, message:No message available}` in 5ms (route doesn't exist, never hits resolver code)
- `/opt/spinnaker/config/clouddriver.yml` has no `ecs:` section
- The `clouddriver-ecs.jar` *contains* `EcsImagesController` and `EcrDockerTagResolver` (with all PR #92/#93 changes) but Spring never wires them

## What this PR does

- **`EcrDockerTagResolver`**: moved from `clouddriver-ecs.provider.view` to `clouddriver-aws.provider.view` (package updated, no behavior change).
- **`EcrImagesController`** (new): lightweight controller in `clouddriver-aws` exposing `/ecr/images/resolveDockerTag` and `/ecr/images/resolveDockerTagByName`. Loads whenever AWS is enabled — the actual prerequisite, since the resolver only needs `NetflixAmazonCredentials` to call ECR `DescribeImages`.
- **`EcsImagesController`**: stripped of the `resolveDockerTag` methods; keeps `findImage` which is genuinely ECS-specific.
- **orca `OortService`**: `@GET` paths updated from `/ecs/images/...` to `/ecr/images/...`.
- **`EcrDockerLatestResolver`**: javadoc updated to reference the new paths.

## Why the URL prefix changed too

`/ecs/images/...` was misleading once the controller no longer lived in the ECS module. The new path `/ecr/images/...` matches the AWS service it actually wraps (Elastic Container Registry, not Elastic Container Service).

## Test plan
- [ ] `EcrDockerTagResolverTest` runs in the new module (uses `NetflixAmazonCredentials` mock — `NetflixECSCredentials` is no longer accessible from `clouddriver-aws`)
- [ ] After deploy: `curl http://localhost:7002/ecr/images/resolveDockerTagByName?repository=moderne/audit-reader-arm64&tag=latest` returns a real resolved semver (e.g. `0.148.118`)
- [ ] Repave-allstate find stages produce `version: 0.148.118` (or current semver), not `latest`