### PR TITLE
fix(orca): execute Retrofit 2 Call in force-cache-refresh recovery path

### DIFF
--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTask.groovy
@@ -217,8 +217,8 @@ class ServerGroupCacheForceRefreshTask implements CloudProviderAware, RetryableT
               model,
               executionId
             )
-            def response = cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model)
-            if (response.status == HttpURLConnection.HTTP_OK) {
+            def response = Retrofit2SyncCall.executeCall(cacheService.forceCacheUpdate(cloudProvider, REFRESH_TYPE, model))
+            if (response.code() == HttpURLConnection.HTTP_OK) {
               // cache update was applied immediately, no need to poll for completion
               log.debug(
                 "Processed force cache refresh request immediately (model: {}, executionId: {})",

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/servergroup/ServerGroupCacheForceRefreshTaskSpec.groovy
@@ -190,6 +190,32 @@ class ServerGroupCacheForceRefreshTaskSpec extends Specification {
   }
 
   @Unroll
+  void "should re-force cache refresh via HTTP when no pending update is found"() {
+    given:
+    def stageData = new ServerGroupCacheForceRefreshTask.StageData(
+      deployServerGroups: [
+        "us-west-1": ["s-v001"] as Set<String>
+      ]
+    )
+
+    when:
+    def processingComplete = task.processPendingForceCacheUpdates("executionId", "test", "aws", stageData, 0)
+
+    then:
+    1 * task.cacheStatusService.pendingForceCacheUpdates("aws", "ServerGroup") >> { Calls.response([]) }
+    1 * task.cacheService.forceCacheUpdate("aws", "ServerGroup", _) >> {
+      Calls.response(Response.success(retryResponseCode, ResponseBody.create(MediaType.parse("application/json"), "")))
+    }
+    stageData.errors.isEmpty()
+    processingComplete == expectedProcessingComplete
+
+    where:
+    retryResponseCode || expectedProcessingComplete
+    HTTP_OK           || true
+    HTTP_ACCEPTED     || false
+  }
+
+  @Unroll
   void "should correctly extract `zone` from `zones` in StageData"() {
     given:
     def objectMapper = new ObjectMapper()


### PR DESCRIPTION
## Summary

- `ServerGroupCacheForceRefreshTask`'s "no pending update found → force a new refresh" recovery branch was missed during the kork Retrofit 1 → 2 migration: it assigned the returned `Call<ResponseBody>` to `response` without executing it and accessed Retrofit-1's `.status` on the Call.
- The Groovy `MissingPropertyException` ("No such property: status for class: ...ExecutorCallbackCall") was swallowed into `force.cache.refresh.errors`, and — more consequentially — the recovery `POST /cache/{cloudProvider}/ServerGroup` was never actually issued, leaving the cache un-refreshed and pushing downstream stages (e.g. `scaleDownCluster`) into timeouts.
- Aligned the call site with the already-migrated sibling at `ServerGroupCacheForceRefreshTask.groovy:141`: wrap with `Retrofit2SyncCall.executeCall(...)` and use `.code()`.

## Test plan

- [x] Added `ServerGroupCacheForceRefreshTaskSpec` row exercising the recovery branch (no pending updates → forceCacheUpdate stubbed with HTTP_OK / HTTP_ACCEPTED). Pre-fix the test reproduced the exact production exception string; post-fix it passes.
- [x] Full `:orca:orca-clouddriver:test --tests ServerGroupCacheForceRefreshTaskSpec` green.
- [ ] Observe real billtrust-style deploy pipeline: `force.cache.refresh.errors` should stop appearing and downstream `scaleDownCluster` should no longer wait on cache convergence that never happens.