### PR TITLE
fix(azure): log ARM error details on failed deployments

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -17,6 +17,7 @@
 package com.netflix.spinnaker.clouddriver.azure.client
 
 import com.azure.core.credential.TokenCredential
+import com.azure.core.management.exception.ManagementError
 import com.azure.core.management.exception.ManagementException
 import com.azure.core.management.profile.AzureProfile
 import com.azure.resourcemanager.network.models.Network
@@ -223,7 +224,7 @@ class AzureResourceManagerClient extends AzureBaseClient {
           .create()
       })
     } catch (Throwable e) {
-      log.error("Exception occured during deployment ${e.message}")
+      logDeploymentFailure(resourceGroupName, deploymentName, e)
       throw e
     } finally {
       logDeploymentTemplate(deploymentName, template, templateParameters)
@@ -232,6 +233,55 @@ class AzureResourceManagerClient extends AzureBaseClient {
 
   static void logDeploymentTemplate(String deploymentName, String template, Map<String, Object> parameters) {
     log.info("Template for deployment {}: {}\nTemplate Parameters: {}", deploymentName, template, parameters.toMapString())
+  }
+
+  /**
+   * Surface as much ARM error detail as possible when a deployment fails.
+   *
+   * The Azure SDK's {@code ManagementException} carries the structured ARM
+   * error model on {@code getValue()} (code / message / target / details),
+   * but {@code e.message} drops it on the floor for LRO terminations —
+   * leaving only "Long running operation is Failed or Cancelled." in the
+   * logs and nothing to act on.
+   *
+   * After logging the exception, attempt to fetch the deployment's per-resource
+   * operations from Azure. When an LRO fails mid-deployment, the failing
+   * sub-operation's {@code statusMessage} is the actual reason ARM gave.
+   * Fetch failures are non-fatal — the original exception is what callers
+   * react to; this is observability.
+   */
+  private void logDeploymentFailure(String resourceGroupName, String deploymentName, Throwable e) {
+    if (e instanceof ManagementException) {
+      ManagementError err = ((ManagementException) e).value
+      log.error(
+        "Deployment {} in resource group {} failed: code={}, message={}, target={}, details={}",
+        deploymentName,
+        resourceGroupName,
+        err?.code,
+        err?.message,
+        err?.target,
+        err?.details?.collect { ManagementError d -> "${d.code}: ${d.message}" }
+      )
+    } else {
+      log.error("Deployment ${deploymentName} in resource group ${resourceGroupName} failed", e)
+    }
+
+    try {
+      Deployment deployment = azure.deployments().getByResourceGroup(resourceGroupName, deploymentName)
+      deployment?.deploymentOperations()?.list()?.each { DeploymentOperation op ->
+        if (op.provisioningState() != "Succeeded") {
+          log.error(
+            "  failed operation: target={} state={} statusCode={} statusMessage={}",
+            op.targetResource()?.id() ?: "<none>",
+            op.provisioningState(),
+            op.statusCode(),
+            op.statusMessage()
+          )
+        }
+      }
+    } catch (Throwable fetchErr) {
+      log.debug("Could not fetch deployment operations for {} in {}: {}", deploymentName, resourceGroupName, fetchErr.message)
+    }
   }
 
   /**

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureResourceManagerClient.groovy
@@ -236,19 +236,13 @@ class AzureResourceManagerClient extends AzureBaseClient {
   }
 
   /**
-   * Surface as much ARM error detail as possible when a deployment fails.
-   *
-   * The Azure SDK's {@code ManagementException} carries the structured ARM
-   * error model on {@code getValue()} (code / message / target / details),
-   * but {@code e.message} drops it on the floor for LRO terminations —
-   * leaving only "Long running operation is Failed or Cancelled." in the
-   * logs and nothing to act on.
-   *
-   * After logging the exception, attempt to fetch the deployment's per-resource
-   * operations from Azure. When an LRO fails mid-deployment, the failing
-   * sub-operation's {@code statusMessage} is the actual reason ARM gave.
-   * Fetch failures are non-fatal — the original exception is what callers
-   * react to; this is observability.
+   * {@code ManagementException.getValue()} carries the parsed ARM error model
+   * (code/message/target/details) that {@code e.message} drops on LRO
+   * terminations — there the message is just "Long running operation is Failed
+   * or Cancelled." After logging, fetch the deployment's per-resource
+   * operations so the failing sub-operation's {@code statusMessage} is also
+   * captured. Fetch failures are demoted to debug; the original exception
+   * still propagates.
    */
   private void logDeploymentFailure(String resourceGroupName, String deploymentName, Throwable e) {
     if (e instanceof ManagementException) {
@@ -269,7 +263,7 @@ class AzureResourceManagerClient extends AzureBaseClient {
     try {
       Deployment deployment = azure.deployments().getByResourceGroup(resourceGroupName, deploymentName)
       deployment?.deploymentOperations()?.list()?.each { DeploymentOperation op ->
-        if (op.provisioningState() != "Succeeded") {
+        if (op.provisioningState() != AzureUtilities.ProvisioningState.SUCCEEDED) {
           log.error(
             "  failed operation: target={} state={} statusCode={} statusMessage={}",
             op.targetResource()?.id() ?: "<none>",


### PR DESCRIPTION
## Summary

- `AzureResourceManagerClient.createTemplateDeployment` was logging only `e.message` on failure. For Azure SDK `ManagementException`, that drops the structured ARM error model (`code` / `message` / `target` / `details`) carried on `getValue()`, and for LRO terminations it leaves operators with just *"Long running operation is Failed or Cancelled."* — no code, no target, no actionable signal.
- Catch `ManagementException` specifically and log the parsed `ManagementError` fields. Fall back to logging with stack trace for non-Management throwables.
- After the exception is logged, attempt to fetch the deployment's per-resource operations and log each failed one's `statusMessage`. When an LRO fails partway through, this is where the real ARM rejection reason lives. Fetch failures are demoted to `debug` — observability shouldn't change which exception callers see.

## Why now

Triaging a failed `deploy-pentestazure` execution (Spinnaker pipeline `01KS0QVWRG0A5V54HF7JDDF2WR`, kato task `2f51e856-cbe5-4dde-998d-5d9075755399`) cost ~30 minutes because clouddriver logged only:

```
Exception occured during deployment Long running operation is Failed or Cancelled.
```

The deployment record wasn't created in Azure (so even `az deployment operation list` wouldn't have helped), meaning the rejection happened at submission time — and the actual reason was sitting in the HTTP response body that `e.message` swallowed.

## Test plan

- [x] `:clouddriver:clouddriver-azure:compileGroovy` clean (the class is `@CompileStatic`, so the new `ManagementError` / `DeploymentOperation` references are compile-time verified).
- [ ] No unit test added — the existing module has no test for `AzureResourceManagerClient`, and the Azure SDK fluent-builder chain (`azure.deployments().define(...).withExistingResourceGroup(...)...create()`) is awkward to mock without scaffolding that dwarfs this change. The success path is unchanged; the failure path is logging only.
- Note: `:clouddriver:clouddriver-azure:test` has 27 pre-existing failures on `main` unrelated to this change (verified by stashing this diff and re-running) — `AzureServerGroupResourceTemplateSpec`, `UpsertAzureAppGatewayAtomicOperationSpec`, etc. Worth a separate cleanup pass.

## Verification once merged

Next time a deploy fails in production, the clouddriver log should show something like:

```
Deployment foo-v000-serverGroup-deployment in resource group foo-v2 failed:
  code=AuthorizationFailed, message=The client '...' does not have authorization to perform action..., target=null, details=[]
  failed operation: target=/subscriptions/.../Microsoft.Compute/virtualMachineScaleSets/foo-v000 state=Failed statusCode=Forbidden statusMessage=...
```

instead of `"Long running operation is Failed or Cancelled."`.