### PR TITLE
orca,gate: rename deploymentSnapshot endpoints to fix routing + naming

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
@@ -41,7 +41,7 @@ public interface OrcaService {
   /**
    * Batch counterpart to {@link #getPipelines}: returns recent pipeline executions across
    * every application in {@code applications} in a single round trip, projected to the
-   * minimal fields a deploy-overview dashboard needs (see Orca's DeploymentExecutionView).
+   * minimal fields a deploy-overview dashboard needs (Orca's PipelineExecutionSummary).
    *
    * <p>Retrofit serializes the List as {@code ?applications=a&applications=b&applications=c};
    * Spring's default conversion service binds either repeated or comma-joined params to
@@ -49,8 +49,8 @@ public interface OrcaService {
    * {@code ClouddriverService.getServerGroups(applications, …)} pattern.
    */
   @Headers("Accept: application/json")
-  @GET("v2/applications:deploymentExecutions")
-  Call<List<Map<String, Object>>> getDeploymentExecutions(
+  @GET("deploymentSnapshots")
+  Call<List<Map<String, Object>>> getDeploymentSnapshots(
       @Query("applications") List<String> applications,
       @Query("pipelineNameFilter") String pipelineNameFilter,
       @Query("statuses") String statuses,

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
@@ -18,7 +18,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -31,7 +30,6 @@ import org.springframework.web.bind.annotation.RestController;
  *
  * <p>Response: projected to the minimal fields a deploy-overview dashboard consumes.
  */
-@RequestMapping("/applications")
 @RestController
 public class DeploymentSnapshotController {
 
@@ -43,8 +41,8 @@ public class DeploymentSnapshotController {
 
   @Operation(
       summary =
-          "Retrieve a projected deploy-overview snapshot (server groups + pipeline configs + recent executions) for many applications in one request")
-  @GetMapping(value = ":deploymentSnapshot")
+          "Retrieve a deploy-overview status snapshot (server groups + pipeline configs + recent executions) for many applications in one request")
+  @GetMapping(value = "/deploymentSnapshot")
   public Snapshot getDeploymentSnapshot(
       @Parameter(
               name = "applications",

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
@@ -40,7 +40,7 @@ import org.springframework.stereotype.Component;
  *   <li>Clouddriver: one multi-app {@code /serverGroups?applications=…} call (in-memory cache).
  *   <li>Front50: one {@code /pipelines} call (in-memory cache); we filter to the requested apps
  *       here.
- *   <li>Orca: one {@code /v2/applications:deploymentExecutions} call (one SQL query).
+ *   <li>Orca: one {@code /deploymentSnapshots} call (one SQL query).
  * </ul>
  *
  * <p>Each shape is projected to the minimal fields a deploy-overview dashboard needs before
@@ -115,9 +115,9 @@ public class DeploymentSnapshotService {
                 Retrofit2SyncCall.execute(
                     orcaServiceSelector
                         .select()
-                        .getDeploymentExecutions(
+                        .getDeploymentSnapshots(
                             applicationsForOrca, pipelineNameFilter, null, pipelineLimit)),
-            "orca deploymentExecutions batch");
+            "orca deploymentSnapshots batch");
 
     CompletableFuture.allOf(sgFuture, pipelinesFuture, execsFuture).join();
     List<Map<String, Object>> rawServerGroups = sgFuture.join();

--- a/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsController.java
+++ b/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsController.java
@@ -42,7 +42,7 @@ import org.springframework.http.HttpStatus;
  * accepts one application per request — fine for Deck's single-app pages but a 60×-round-trip
  * pattern for dashboards that need to summarize the deploy state of every service at once.
  *
- * <p>Projection: returns {@link DeploymentExecutionView}, a slim summary of each execution
+ * <p>Projection: returns {@link PipelineExecutionSummary}, a slim summary of each execution
  * (ids, status, timestamps, trigger summary, stage list). Drops outputs/context/tasks/
  * notifications, which typically account for 90%+ of an execution's serialized weight but
  * aren't needed for top-level dashboards.
@@ -51,12 +51,12 @@ import org.springframework.http.HttpStatus;
  * READ permission on, matching the per-app guard on {@code getPipelinesForApplication}.
  */
 @RestController
-public class DeploymentExecutionsController {
+public class DeploymentSnapshotsController {
 
   private final ExecutionRepository executionRepository;
   @Nullable private final Front50Service front50Service;
 
-  public DeploymentExecutionsController(
+  public DeploymentSnapshotsController(
       ExecutionRepository executionRepository, @Nullable Front50Service front50Service) {
     this.executionRepository = executionRepository;
     this.front50Service = front50Service;
@@ -77,8 +77,8 @@ public class DeploymentExecutionsController {
       value = "hasPermission(filterObject, 'APPLICATION', 'READ')",
       filterTarget = "applications")
   @PostFilter("hasPermission(filterObject.application, 'APPLICATION', 'READ')")
-  @GetMapping(value = "/v2/applications:deploymentExecutions", produces = APPLICATION_JSON_VALUE)
-  public List<DeploymentExecutionView> getDeploymentExecutions(
+  @GetMapping(value = "/deploymentSnapshots", produces = APPLICATION_JSON_VALUE)
+  public List<PipelineExecutionSummary> getDeploymentSnapshots(
       @RequestParam("applications") List<String> applications,
       @RequestParam(value = "pipelineNameFilter", required = false) String pipelineNameFilter,
       @RequestParam(value = "statuses", required = false) String statuses,
@@ -139,8 +139,8 @@ public class DeploymentExecutionsController {
         executionRepository.retrievePipelineExecutionsForApplications(
             applications, configIds, criteria, queryTimeoutSeconds);
 
-    List<DeploymentExecutionView> out = new ArrayList<>(executions.size());
-    for (PipelineExecution e : executions) out.add(DeploymentExecutionView.from(e));
+    List<PipelineExecutionSummary> out = new ArrayList<>(executions.size());
+    for (PipelineExecution e : executions) out.add(PipelineExecutionSummary.from(e));
     // Sort newest first by startTime then id, matching getPipelinesForApplication.
     out.sort(
         (a, b) -> {

--- a/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/PipelineExecutionSummary.java
+++ b/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/PipelineExecutionSummary.java
@@ -34,7 +34,7 @@ import java.util.Optional;
  * point where browser JSON parsing becomes the bottleneck.
  */
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class DeploymentExecutionView {
+public class PipelineExecutionSummary {
 
   public String id;
   public String name;
@@ -87,8 +87,8 @@ public class DeploymentExecutionView {
     public String failureMessage;
   }
 
-  public static DeploymentExecutionView from(PipelineExecution exec) {
-    DeploymentExecutionView v = new DeploymentExecutionView();
+  public static PipelineExecutionSummary from(PipelineExecution exec) {
+    PipelineExecutionSummary v = new PipelineExecutionSummary();
     v.id = exec.getId();
     v.name = exec.getName();
     v.application = exec.getApplication();

--- a/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsControllerTest.java
+++ b/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsControllerTest.java
@@ -42,11 +42,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = {DeploymentExecutionsController.class}, webEnvironment = MOCK)
+@SpringBootTest(classes = {DeploymentSnapshotsController.class}, webEnvironment = MOCK)
 @AutoConfigureMockMvc
 @EnableWebMvc
 @WithMockUser("dashboard")
-class DeploymentExecutionsControllerTest {
+class DeploymentSnapshotsControllerTest {
 
   @MockBean ExecutionRepository executionRepository;
   @MockBean com.netflix.spinnaker.orca.front50.Front50Service front50Service;
@@ -58,7 +58,7 @@ class DeploymentExecutionsControllerTest {
     when(executionRepository.retrievePipelineExecutionsForApplications(any(), any(), any(), anyInt()))
         .thenReturn(List.of(buildExecution("svc-a", "exec-1"), buildExecution("svc-b", "exec-2")));
 
-    mvc.perform(get("/v2/applications:deploymentExecutions").param("applications", "svc-a,svc-b"))
+    mvc.perform(get("/deploymentSnapshots").param("applications", "svc-a,svc-b"))
         .andExpect(status().is2xxSuccessful())
         // Both apps are represented in the response.
         .andExpect(jsonPath("$[*].application").value(
@@ -70,7 +70,7 @@ class DeploymentExecutionsControllerTest {
 
   @Test
   void emptyApplicationsListShortCircuits() throws Exception {
-    mvc.perform(get("/v2/applications:deploymentExecutions").param("applications", ""))
+    mvc.perform(get("/deploymentSnapshots").param("applications", ""))
         .andExpect(status().is2xxSuccessful())
         .andExpect(content().json("[]"));
 
@@ -93,7 +93,7 @@ class DeploymentExecutionsControllerTest {
     when(executionRepository.retrievePipelineExecutionsForApplications(any(), any(), any(), anyInt()))
         .thenReturn(List.of(exec));
 
-    mvc.perform(get("/v2/applications:deploymentExecutions").param("applications", "svc-a"))
+    mvc.perform(get("/deploymentSnapshots").param("applications", "svc-a"))
         .andExpect(status().is2xxSuccessful())
         .andExpect(jsonPath("$[0].stages[0].failureMessage")
             .value("ASG never reached desired capacity"));


### PR DESCRIPTION
## Summary

- Follow-up to #96. Two issues surfaced when smoke-testing the new endpoints against the deployed Gate:

**1. Gate `/applications:deploymentSnapshot` 404'd.** Spring's `AntPathMatcher.combine(pattern1, pattern2)` inserts a `/` separator between class-level `@RequestMapping("/applications")` and method-level `@GetMapping(":deploymentSnapshot")`, producing the registered pattern `/applications/:deploymentSnapshot`. The dashboard sends `/applications:deploymentSnapshot` (no slash), which never matches. Confirmed by `curl`-ing the live endpoint after the merge.

**2. The `:verb` URL style is foreign to Spinnaker.** Borrowed from Google AIP-136 (custom methods); zero precedent elsewhere in Gate or Orca. Every literal-colon usage in the codebase is inside `{var:.+}` regex syntax for path variables, not a path-segment suffix. Idiomatic Spinnaker uses top-level plural-noun resources with query-param filters (`/serverGroups?applications=a,b,c`).

## Renames

| Layer | Before | After |
|---|---|---|
| Gate URL | `GET /applications:deploymentSnapshot` | `GET /deploymentSnapshot` (returns one `Snapshot`) |
| Orca URL | `GET /v2/applications:deploymentExecutions` | `GET /deploymentSnapshots` (returns a list of summaries) |
| Orca controller | `DeploymentExecutionsController` | `DeploymentSnapshotsController` |
| Orca DTO | `DeploymentExecutionView` | `PipelineExecutionSummary` |
| Gate retrofit method | `OrcaService.getDeploymentExecutions` | `OrcaService.getDeploymentSnapshots` |

Singular Gate / plural Orca matches what each endpoint actually returns — Gate returns one aggregated snapshot, Orca returns the list of per-execution summaries that composes (part of) it.

## Test plan

- [x] `:gate:gate-web:classes`, `:orca:orca-web:test --tests DeploymentSnapshotsControllerTest` clean locally.
- [ ] After deploy: `curl /spinnaker-api/deploymentSnapshot?applications=recipeworker2&pipelineNameFilter=deploy-&pipelineLimit=2` against dev Gate, confirm 200 with the projected JSON shape.
- [ ] Status dashboard loads end-to-end against the new endpoint.

Companion PR on the client side: moderneinc/moderne-saas (updates `aggregator.ts` to hit `/deploymentSnapshot`).
