### PR TITLE
gate: parameterize List<String> on Clouddriver getServerGroups retrofit

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/ClouddriverService.java
@@ -133,8 +133,8 @@ public interface ClouddriverService {
   @Headers("Accept: application/json")
   @GET("serverGroups")
   Call<List> getServerGroups(
-      @Query("applications") List applications,
-      @Query("ids") List ids,
+      @Query("applications") List<String> applications,
+      @Query("ids") List<String> ids,
       @Query("cloudProvider") String cloudProvider);
 
   @Headers("Accept: application/json")


### PR DESCRIPTION
## Summary

Retrofit 2.x rejects raw `List` query parameters at serialization time:

```
java.lang.IllegalArgumentException: List must include generic type (e.g., List<String>)
    - (parameter #1) for method ClouddriverService.getServerGroups
```

So Gate's existing multi-app `GET /serverGroups?applications=a,b,c` endpoint has been returning 400 for every caller — `ServerGroupController` accepts the inbound request, but the downstream `ClouddriverService.getServerGroups(List, List, String)` retrofit call blows up before the response leaves Gate.

`ServerGroupService.getForApplications` and `getForIds` already pass `List<String>` from the call site, so this just aligns the retrofit signature with what's actually flowing through it. Single-app `/applications/{app}/serverGroups` is unaffected (different overload, no `List` param).

- Found while smoke-testing the multi-app deployment-snapshot fan-out from #96/#98 — Gate's snapshot aggregator calls into this exact retrofit method and gets the same 400 back.

## Test plan

- [x] `./gradlew :gate:gate-web:compileGroovy :gate:gate-web:compileTestGroovy` clean.
- [ ] After deploy: `curl /spinnaker-api/serverGroups?applications=recipeworker2&applications=gateway2`, confirm 200 with per-app SG entries.
- [ ] Rerun the dashboard smoke test — `/deploymentSnapshot` should now return non-empty `serverGroups` per app.
