### PR TITLE
fix(azure): catch ResourceNotFound in on-demand cache handler

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
@@ -246,7 +246,14 @@ abstract class AzureBaseClient {
   }
 
   static Boolean resourceNotFound(Exception e) {
-    e.class == ManagementException ? (e as ManagementException).getResponse().getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND : false
+    // Use instanceof so subclasses of ManagementException (the Azure SDK can
+    // surface a typed subclass for certain ARM error families) still match.
+    // Strict class equality let 404s bypass executeOp's "return null on
+    // not-found" short-circuit, causing the AzureServerGroupCachingAgent
+    // on-demand handler to throw on a deleted VMSS instead of writing an
+    // eviction tombstone — which left Orca's force-cache-refresh recovery
+    // path looping until the queue saturated.
+    e instanceof ManagementException && (e as ManagementException).getResponse().getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND
   }
 
   /***

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
@@ -162,11 +162,11 @@ abstract class AzureBaseClient {
    */
   private static boolean canRetry(Exception e) {
     boolean retry = false
-    if (e.class == ManagementException) {
+    if (e instanceof ManagementException) {
       def code = (e as ManagementException).getResponse().getStatusCode()
       retry = (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT
         || (code >= HttpURLConnection.HTTP_INTERNAL_ERROR && code <= HttpURLConnection.HTTP_GATEWAY_TIMEOUT))
-    } else if (e.class == SocketTimeoutException) {
+    } else if (e instanceof SocketTimeoutException) {
       //If we get a socket time out try again
       retry = true
     }
@@ -180,7 +180,7 @@ abstract class AzureBaseClient {
    * @return True if the exception encountered was a 429 Response and it was handled
    */
   private static boolean handleTooManyRequestsResponse(Exception e) {
-    if (e.class == ManagementException.class) {
+    if (e instanceof ManagementException) {
       def response = (e as ManagementException).getResponse()
       if (response.getStatusCode() == HTTP_TOO_MANY_REQUESTS) {
         int retryAfterIntervalSec = DEFAULT_429_RETRY_INTERVAL_SEC
@@ -246,13 +246,7 @@ abstract class AzureBaseClient {
   }
 
   static Boolean resourceNotFound(Exception e) {
-    // Use instanceof so subclasses of ManagementException (the Azure SDK can
-    // surface a typed subclass for certain ARM error families) still match.
-    // Strict class equality let 404s bypass executeOp's "return null on
-    // not-found" short-circuit, causing the AzureServerGroupCachingAgent
-    // on-demand handler to throw on a deleted VMSS instead of writing an
-    // eviction tombstone — which left Orca's force-cache-refresh recovery
-    // path looping until the queue saturated.
+    // Azure SDK surfaces typed subclasses for some ARM error families; instanceof catches those, strict class equality wouldn't.
     e instanceof ManagementException && (e as ManagementException).getResponse().getStatusCode() == HttpURLConnection.HTTP_NOT_FOUND
   }
 

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -43,6 +43,7 @@ import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
+import static com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient.resourceNotFound
 
 @Slf4j
 class AzureServerGroupCachingAgent extends AzureCachingAgent {
@@ -243,9 +244,18 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
         def sg = creds.computeClient.getServerGroup(resourceGroupName, serverGroupName)
         return sg ?: null
       }
-    } catch (Exception e ) {
-      log.error("handle->Unexpected exception: ${e.message}")
-      return null
+    } catch (Exception e) {
+      // A 404 here means the VMSS is gone. Fall through with serverGroup=null
+      // so the deleted-VMSS branch below writes an eviction tombstone — the
+      // alternative (return null) leaves Orca's force-cache-refresh recovery
+      // path spinning forever waiting for a pending entry that never arrives.
+      // Any other exception is transient; bail without touching the cache.
+      if (resourceNotFound(e)) {
+        log.warn("handle->ServerGroup not found, treating as deleted (resourceGroup: ${resourceGroupName}, serverGroup: ${serverGroupName})")
+      } else {
+        log.error("handle->Unexpected exception: ${e.message}")
+        return null
+      }
     }
 
     def cacheResult = metricsSupport.transformData {

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/cache/AzureServerGroupCachingAgent.groovy
@@ -43,7 +43,7 @@ import groovy.util.logging.Slf4j
 
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.AUTHORITATIVE
 import static com.netflix.spinnaker.cats.agent.AgentDataType.Authority.INFORMATIVE
-import static com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient.resourceNotFound
+import com.netflix.spinnaker.clouddriver.azure.client.AzureBaseClient
 
 @Slf4j
 class AzureServerGroupCachingAgent extends AzureCachingAgent {
@@ -245,17 +245,12 @@ class AzureServerGroupCachingAgent extends AzureCachingAgent {
         return sg ?: null
       }
     } catch (Exception e) {
-      // A 404 here means the VMSS is gone. Fall through with serverGroup=null
-      // so the deleted-VMSS branch below writes an eviction tombstone — the
-      // alternative (return null) leaves Orca's force-cache-refresh recovery
-      // path spinning forever waiting for a pending entry that never arrives.
-      // Any other exception is transient; bail without touching the cache.
-      if (resourceNotFound(e)) {
-        log.warn("handle->ServerGroup not found, treating as deleted (resourceGroup: ${resourceGroupName}, serverGroup: ${serverGroupName})")
-      } else {
+      if (!AzureBaseClient.resourceNotFound(e)) {
         log.error("handle->Unexpected exception: ${e.message}")
         return null
       }
+      // 404: VMSS is gone. Fall through with serverGroup=null so the deleted-VMSS branch below writes an eviction tombstone.
+      log.warn("handle->ServerGroup not found, treating as deleted (resourceGroup: ${resourceGroupName}, serverGroup: ${serverGroupName})")
     }
 
     def cacheResult = metricsSupport.transformData {


### PR DESCRIPTION
## Summary

- `AzureBaseClient.resourceNotFound` now uses `instanceof` instead of strict class equality, so any `ManagementException` subclass is correctly identified as a 404.
- `AzureServerGroupCachingAgent.handle` now treats a not-found in the try/catch as "VMSS deleted" and falls through to the existing eviction-tombstone path, instead of returning null and skipping the cache update.

## Why

- The strict class check in `resourceNotFound` let some 404s slip past `executeOp`'s "return null on not-found" short-circuit, so the not-found propagated up to `AzureServerGroupCachingAgent.handle`. That `catch (Exception)` block then logged and returned null without writing anything to the on-demand cache. After #95 made Orca's force-cache-refresh recovery POST actually fire, the chain failed like this:

1. Orca POSTs `/cache/azure/ServerGroup` for a deleted VMSS.
2. Clouddriver returns HTTP 200 ack.
3. Caching agent throws on the underlying 404 — no pending entry written.
4. Orca polls `pendingOnDemandRequests`, sees nothing, re-fires recovery POST.
5. Repeat forever. Queue saturates, Orca enters Full GC.

Observed in prod: `ServerGroupCacheForceRefreshTask` accumulated 449 retry attempts against `moderneui2` (Azure) inside ~58 min of a fresh Spinnaker deploy, while the JVM did 436 Full GCs / ~66 s of stop-the-world pause, breaking unrelated Gate endpoints (`/deploymentSnapshot` timing out at >25 s) until Orca was restarted.

## Test plan

- [ ] `./gradlew :clouddriver:clouddriver-azure:compileGroovy` passes (verified locally).
- [ ] Manual: trigger a force-cache-refresh against a known-deleted VMSS in a moderne-azure account; confirm the caching agent writes an eviction tombstone in `AZURE_EVICTIONS` and Orca's `pendingForceCacheUpdates` GET no longer returns empty indefinitely.
- [ ] Watch Orca's queue depth + Full GC count after deploy; both should stay flat through a customer Azure repave cycle.