### PR TITLE
orca,gate: trim deploymentSnapshot payload (disabled SGs, exact-name allowlist, lazy stages)

### DIFF
--- a/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
+++ b/gate/gate-core/src/main/java/com/netflix/spinnaker/gate/services/internal/OrcaService.java
@@ -52,7 +52,7 @@ public interface OrcaService {
   @GET("deploymentSnapshots")
   Call<List<Map<String, Object>>> getDeploymentSnapshots(
       @Query("applications") List<String> applications,
-      @Query("pipelineNameFilter") String pipelineNameFilter,
+      @Query("pipelineNames") List<String> pipelineNames,
       @Query("statuses") String statuses,
       @Query("limit") Integer limit);
 

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
@@ -51,11 +51,11 @@ public class DeploymentSnapshotController {
           @RequestParam("applications")
           String applicationsCsv,
       @Parameter(
-              name = "pipelineNameFilter",
+              name = "pipelineNames",
               description =
-                  "Optional substring match on pipeline name (e.g. `deploy-`) — only matching executions and configs are returned")
-          @RequestParam(value = "pipelineNameFilter", required = false)
-          String pipelineNameFilter,
+                  "Optional comma-separated allowlist of exact pipeline names (e.g. `deploy-dev,deploy-devaz`). When set, only executions and configs whose name matches exactly are returned; when omitted, no name filter is applied.")
+          @RequestParam(value = "pipelineNames", required = false)
+          String pipelineNamesCsv,
       @Parameter(
               name = "pipelineLimit",
               description =
@@ -67,6 +67,13 @@ public class DeploymentSnapshotController {
             .map(String::trim)
             .filter(s -> !s.isEmpty())
             .collect(Collectors.toList());
-    return snapshotService.getSnapshot(applications, pipelineNameFilter, pipelineLimit);
+    List<String> pipelineNames =
+        pipelineNamesCsv == null || pipelineNamesCsv.isBlank()
+            ? List.of()
+            : Arrays.stream(pipelineNamesCsv.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toList());
+    return snapshotService.getSnapshot(applications, pipelineNames, pipelineLimit);
   }
 }

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
@@ -44,7 +44,10 @@ import org.springframework.stereotype.Component;
  * </ul>
  *
  * <p>Each shape is projected to the minimal fields a deploy-overview dashboard needs before
- * returning; the projection drops ~90% of bytes off each response.
+ * returning; the projection drops ~90% of bytes off each response. Disabled server groups are
+ * dropped entirely (every cluster accumulates a long tail of historical SGs that dashboards
+ * filter out anyway), and when {@code pipelineNames} is provided the pipeline configs and
+ * executions are restricted to exact-name matches.
  */
 @Component
 public class DeploymentSnapshotService {
@@ -78,10 +81,14 @@ public class DeploymentSnapshotService {
   }
 
   public Snapshot getSnapshot(
-      List<String> applications, String pipelineNameFilter, Integer pipelineLimit) {
+      List<String> applications, List<String> pipelineNames, Integer pipelineLimit) {
     Snapshot snapshot = new Snapshot();
     snapshot.apps = new ArrayList<>();
     if (applications == null || applications.isEmpty()) return snapshot;
+
+    final List<String> pipelineNamesOrEmpty =
+        pipelineNames == null ? List.of() : pipelineNames;
+    final Set<String> pipelineNameSet = new HashSet<>(pipelineNamesOrEmpty);
 
     // Fan out the three backend calls in parallel. Each one short-circuits to an
     // empty list on failure so a single backend hiccup doesn't blank the dashboard.
@@ -116,7 +123,7 @@ public class DeploymentSnapshotService {
                     orcaServiceSelector
                         .select()
                         .getDeploymentSnapshots(
-                            applicationsForOrca, pipelineNameFilter, null, pipelineLimit)),
+                            applicationsForOrca, pipelineNamesOrEmpty, null, pipelineLimit)),
             "orca deploymentSnapshots batch");
 
     CompletableFuture.allOf(sgFuture, pipelinesFuture, execsFuture).join();
@@ -138,6 +145,12 @@ public class DeploymentSnapshotService {
     }
 
     for (Map<String, Object> sg : rawServerGroups) {
+      // Skip disabled server groups outright — every cluster accumulates a long
+      // tail of `isDisabled: true` historical SGs and every known caller of this
+      // endpoint discards them anyway. Filtering here saves ~85% of the
+      // serverGroups payload on a typical fleet snapshot.
+      if (Boolean.TRUE.equals(sg.get("isDisabled"))) continue;
+
       Object appName = sg.get("application");
       // Clouddriver doesn't always echo `application` on its multi-app response, but it does
       // populate `moniker.app` (frigga-derived) and `name` (which starts with the app name).
@@ -152,12 +165,12 @@ public class DeploymentSnapshotService {
     for (Map<String, Object> p : rawPipelineConfigs) {
       Object app = p.get("application");
       if (!(app instanceof String) || !wantedApps.contains(app)) continue;
-      // Apply the same pipelineNameFilter to configs that Orca applies to executions, so
-      // both lists are consistent and the client doesn't receive every pipeline config in
-      // the cluster when only `deploy-*` was requested.
-      if (pipelineNameFilter != null && !pipelineNameFilter.isBlank()) {
+      // Apply the same pipelineNames allowlist to configs that Orca applies to executions,
+      // so both lists are consistent and the client doesn't receive every pipeline config
+      // in the cluster when only specific deploy names were requested.
+      if (!pipelineNameSet.isEmpty()) {
         Object name = p.get("name");
-        if (!(name instanceof String) || !((String) name).contains(pipelineNameFilter)) continue;
+        if (!(name instanceof String) || !pipelineNameSet.contains(name)) continue;
       }
       byApp.get(app).pipelineConfigs.add(projectPipelineConfig(p));
     }

--- a/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsController.java
+++ b/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsController.java
@@ -80,7 +80,7 @@ public class DeploymentSnapshotsController {
   @GetMapping(value = "/deploymentSnapshots", produces = APPLICATION_JSON_VALUE)
   public List<PipelineExecutionSummary> getDeploymentSnapshots(
       @RequestParam("applications") List<String> applications,
-      @RequestParam(value = "pipelineNameFilter", required = false) String pipelineNameFilter,
+      @RequestParam(value = "pipelineNames", required = false) List<String> pipelineNames,
       @RequestParam(value = "statuses", required = false) String statuses,
       @RequestParam(value = "limit", defaultValue = "5") int limit,
       @RequestParam(value = "queryTimeoutSeconds", defaultValue = "10") int queryTimeoutSeconds) {
@@ -105,6 +105,15 @@ public class DeploymentSnapshotsController {
             .collect(Collectors.toList());
     if (applications.isEmpty()) return List.of();
 
+    Set<String> pipelineNameAllowlist =
+        pipelineNames == null
+            ? Set.of()
+            : pipelineNames.stream()
+                .filter(a -> a != null)
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(Collectors.toCollection(LinkedHashSet::new));
+
     ExecutionCriteria criteria = new ExecutionCriteria();
     criteria.setPageSize(limit);
     if (statuses != null && !statuses.isBlank()) {
@@ -118,19 +127,20 @@ public class DeploymentSnapshotsController {
           Arrays.stream(ExecutionStatus.values()).map(Enum::name).collect(Collectors.toList()));
     }
 
-    // Resolve pipelineNameFilter via front50's getAllPipelines once (in-memory at front50),
-    // then filter to the requested apps + name prefix. The resulting config_ids are the
-    // restriction we pass to the SQL repo; passing an empty list means "no config_id filter".
+    // Resolve pipelineNames via front50's getAllPipelines once (in-memory at front50),
+    // then filter to the requested apps + exact-name matches. The resulting config_ids are
+    // the restriction we pass to the SQL repo; passing an empty list means "no config_id
+    // filter".
     //
     // If front50 isn't wired up (e.g. test contexts), we simply skip the filter and let the
     // repo return everything for the apps — matches getPipelinesForApplication's behavior.
     // If front50 IS wired up but fails, we let the exception propagate: a 503 is honest, and
     // silently returning empty results would make front50 outages look like "no deploys."
     List<String> configIds = List.of();
-    if (front50Service != null && pipelineNameFilter != null && !pipelineNameFilter.isBlank()) {
-      configIds = resolveConfigIds(applications, pipelineNameFilter);
+    if (front50Service != null && !pipelineNameAllowlist.isEmpty()) {
+      configIds = resolveConfigIds(applications, pipelineNameAllowlist);
       if (configIds.isEmpty()) {
-        // Filter matches zero pipelines — short-circuit before hitting SQL.
+        // Allowlist matches zero pipelines — short-circuit before hitting SQL.
         return List.of();
       }
     }
@@ -152,11 +162,12 @@ public class DeploymentSnapshotsController {
     return out;
   }
 
-  private List<String> resolveConfigIds(List<String> applications, String pipelineNameFilter) {
+  private List<String> resolveConfigIds(
+      List<String> applications, Set<String> pipelineNameAllowlist) {
     // Don't swallow front50 failures: a 503 here is honest. The Gate aggregator's
     // catch-and-degrade still lets the dashboard render with empty execution data,
     // but the underlying error gets logged at the right layer instead of being
-    // misread as "no deploys match this filter."
+    // misread as "no deploys match the allowlist."
     List<Map<String, Object>> allPipelines =
         Retrofit2SyncCall.execute(front50Service.getAllPipelines());
     Set<String> wantedApps = new HashSet<>(applications);
@@ -167,7 +178,7 @@ public class DeploymentSnapshotsController {
       Object id = p.get("id");
       if (!(app instanceof String) || !(name instanceof String) || !(id instanceof String)) continue;
       if (!wantedApps.contains(app)) continue;
-      if (!((String) name).contains(pipelineNameFilter)) continue;
+      if (!pipelineNameAllowlist.contains(name)) continue;
       ids.add((String) id);
     }
     return new ArrayList<>(ids);

--- a/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/PipelineExecutionSummary.java
+++ b/orca/orca-web/src/main/java/com/netflix/spinnaker/orca/controllers/PipelineExecutionSummary.java
@@ -17,7 +17,6 @@ import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution;
 import com.netflix.spinnaker.orca.api.pipeline.models.Trigger;
 import com.netflix.spinnaker.orca.pipeline.model.DockerTrigger;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -25,9 +24,16 @@ import java.util.Optional;
 
 /**
  * Minimal projection of a {@link PipelineExecution} for dashboards that fan out across many
- * applications and only need surface-level status. Drops outputs/context/tasks/notifications and
- * keeps just the fields needed to render a deploy-pipeline overview: ids, status, timestamps,
- * trigger summary, and a stage-summary list.
+ * applications and only need surface-level status. Drops outputs/context/tasks/notifications/
+ * stages and keeps just the fields needed to render a deploy-pipeline overview: ids, status,
+ * timestamps, trigger summary, and a top-level failure message lifted from the first failed
+ * stage so failure reasons stay legible without the stage list.
+ *
+ * <p>Stage detail is deliberately excluded: dashboards render a stage strip only when the user
+ * focuses a single execution, and at that point can fetch the full execution body via Gate's
+ * existing {@code GET /pipelines/{id}} endpoint. Inlining stages into every snapshot would
+ * dominate the payload (5-10 stages per execution × 100s of executions per snapshot) for data
+ * that's only consumed on click.
  *
  * <p>Serializing the projection rather than the full {@code PipelineExecution} cuts each
  * snapshot's wire size by ~20-50x in practice and keeps the dashboard's payload below the
@@ -44,7 +50,12 @@ public class PipelineExecutionSummary {
   public Long startTime;
   public Long endTime;
   public TriggerView trigger;
-  public List<StageView> stages;
+  /**
+   * First non-empty failure string lifted from the failed stages, so a dashboard can render
+   * the actual reason ("Wait for cluster healthy timed out") next to a red execution without
+   * having to fetch the full stage list.
+   */
+  public String failureMessage;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class TriggerView {
@@ -71,22 +82,6 @@ public class PipelineExecutionSummary {
     public ArtifactView boundArtifact;
   }
 
-  @JsonInclude(JsonInclude.Include.NON_NULL)
-  public static class StageView {
-    public String id;
-    public String name;
-    public String type;
-    public ExecutionStatus status;
-    public Long startTime;
-    public Long endTime;
-    public String refId;
-    public Collection<String> requisiteStageRefIds;
-    public String parentStageId;
-    public String syntheticStageOwner;
-    /** Failure message, lifted from `context.exception.details.errors[0]` when not set directly. */
-    public String failureMessage;
-  }
-
   public static PipelineExecutionSummary from(PipelineExecution exec) {
     PipelineExecutionSummary v = new PipelineExecutionSummary();
     v.id = exec.getId();
@@ -97,7 +92,7 @@ public class PipelineExecutionSummary {
     v.startTime = exec.getStartTime();
     v.endTime = exec.getEndTime();
     v.trigger = projectTrigger(exec.getTrigger());
-    v.stages = projectStages(exec.getStages());
+    v.failureMessage = pickFailureMessage(exec.getStages());
     return v;
   }
 
@@ -149,27 +144,19 @@ public class PipelineExecutionSummary {
     return tv;
   }
 
-  private static List<StageView> projectStages(List<StageExecution> stages) {
+  /**
+   * Find the first non-empty failure string across the failed stages. Walks stages in
+   * declaration order — good enough for a one-line dashboard summary; the click-through
+   * detail view (Gate's {@code /pipelines/{id}}) can reconstruct the full stage graph.
+   */
+  private static String pickFailureMessage(List<StageExecution> stages) {
     if (stages == null || stages.isEmpty()) return null;
-    List<StageView> out = new ArrayList<>(stages.size());
     for (StageExecution s : stages) {
-      StageView sv = new StageView();
-      sv.id = s.getId();
-      sv.name = s.getName();
-      sv.type = s.getType();
-      sv.status = s.getStatus();
-      sv.startTime = s.getStartTime();
-      sv.endTime = s.getEndTime();
-      sv.refId = s.getRefId();
-      sv.requisiteStageRefIds = s.getRequisiteStageRefIds();
-      sv.parentStageId = s.getParentStageId();
-      if (s.getSyntheticStageOwner() != null) {
-        sv.syntheticStageOwner = s.getSyntheticStageOwner().toString();
-      }
-      sv.failureMessage = extractFailureMessage(s);
-      out.add(sv);
+      if (s.getStatus() == null || !s.getStatus().isFailure()) continue;
+      String msg = extractFailureMessage(s);
+      if (msg != null && !msg.isEmpty()) return msg;
     }
-    return out;
+    return null;
   }
 
   /**

--- a/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsControllerTest.java
+++ b/orca/orca-web/src/test/groovy/com/netflix/spinnaker/orca/controllers/DeploymentSnapshotsControllerTest.java
@@ -63,8 +63,9 @@ class DeploymentSnapshotsControllerTest {
         // Both apps are represented in the response.
         .andExpect(jsonPath("$[*].application").value(
             org.hamcrest.Matchers.containsInAnyOrder("svc-a", "svc-b")))
-        // The projection drops outputs/context but keeps stages + trigger.
-        .andExpect(jsonPath("$[0].stages").isArray())
+        // The projection keeps trigger + status + timestamps and drops the stage list
+        // entirely (clients fetch /pipelines/{id} for stage detail on click).
+        .andExpect(jsonPath("$[0].stages").doesNotExist())
         .andExpect(jsonPath("$[0].trigger.type").value("manual"));
   }
 
@@ -95,7 +96,7 @@ class DeploymentSnapshotsControllerTest {
 
     mvc.perform(get("/deploymentSnapshots").param("applications", "svc-a"))
         .andExpect(status().is2xxSuccessful())
-        .andExpect(jsonPath("$[0].stages[0].failureMessage")
+        .andExpect(jsonPath("$[0].failureMessage")
             .value("ASG never reached desired capacity"));
   }
 


### PR DESCRIPTION
## Summary

- Three sources of over-fetch in the multi-app deploy snapshot endpoint (`/deploymentSnapshot` on Gate, `/deploymentSnapshots` on Orca, added in #96/#98) were inflating wall-clock time to several seconds on the moderne-saas status page:

- **Disabled server groups** — every cluster accumulates a long tail of `isDisabled: true` historical SGs (sample app: 13 SGs total, 2 active). Every known caller filters them client-side. Drop them in Gate's `projectServerGroup` so they never leave Clouddriver.
- **Substring name filter** — `pipelineNameFilter=deploy-` returned every `deploy-all` / `deploy-all-fanout` execution alongside the real `deploy-<tenant>` runs. The status page discards them after parse. Replace the substring with a `pipelineNames` exact-match allowlist threaded through Gate → Orca; client sends `deploy-dev,deploy-devaz` and gets back exactly those configs + executions.
- **Per-execution `stages[]`** — dominated the response, but the matrix view never renders stages (only the focused-cell sidebar does). Drop `stages` from `PipelineExecutionSummary` entirely and surface a top-level `failureMessage` lifted off the first failed stage so failure reasons stay legible without the stage list. Clients fetch stage detail lazily via Gate's existing `GET /pipelines/{id}` when a cell is focused.

Combined effect on a ~20-app sample fleet: server groups shrink ~85%, `deploy-all*` executions disappear (~50% of executions per app), and the remaining executions lose their stage tails.

- **Breaking change**: `pipelineNameFilter` (substring) is replaced by `pipelineNames` (CSV of exact names) on both endpoints. They were added in #96/#98 for the moderne-saas status page and have no other callers, so this is a parameter rename rather than a deprecation.

## Test plan

- [ ] `:orca-web:test --tests DeploymentSnapshotsControllerTest` passes (assertions updated for new shape: `$[0].stages` no longer exists; `failureMessage` lifted to top-level).
- [ ] Hit `/deploymentSnapshot?applications=…&pipelineNames=deploy-dev,deploy-devaz` against dev Gate; verify `serverGroups[]` contains only `isDisabled: false` entries, `pipelineConfigs[]` matches the allowlist exactly, and `executions[].stages` is absent.
- [ ] Status page (`status.saas.moderne.io`) page load drops from multi-second to sub-second; focusing a cell still hydrates the stage chiclet strip via the on-click `/pipelines/{id}` fetch.
