### PR TITLE
gate: project ASG tags through the deploymentSnapshot endpoint

### DIFF
--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
@@ -260,6 +260,34 @@ public class DeploymentSnapshotService {
         p.put("launchConfig", minimalLaunchConfig);
       }
     }
+
+    // ASG tags carry the docker image version that the deploy stage stamped onto
+    // the cluster (Moderne's deploy template writes `Version=<docker-tag>` at
+    // createServerGroup time). The bare AWS server-group response carries no
+    // docker metadata - the AMI is a generic Ubuntu base, the tag lives only on
+    // the ASG itself - so without this projection the dashboard has to backfill
+    // imageVersion from the deploy execution, which means pulling executions
+    // for every customer tenant just to learn one tag per cell. Projecting
+    // tags here exposes the data Clouddriver already cached
+    // (`describeAutoScalingGroups` returns tags inline) so callers can read
+    // the version off the SG directly. We strip the propagation/resource-type
+    // metadata each tag carries - only key/value are useful at this layer.
+    Object tags = sg.get("tags");
+    if (tags instanceof List) {
+      List<Map<String, Object>> outTags = new ArrayList<>();
+      for (Object o : (List<?>) tags) {
+        if (!(o instanceof Map)) continue;
+        Map<?, ?> t = (Map<?, ?>) o;
+        Object key = t.get("key");
+        Object value = t.get("value");
+        if (key == null || value == null) continue;
+        Map<String, Object> pt = new LinkedHashMap<>();
+        pt.put("key", key);
+        pt.put("value", value);
+        outTags.add(pt);
+      }
+      if (!outTags.isEmpty()) p.put("tags", outTags);
+    }
     return p;
   }
 


### PR DESCRIPTION
## Summary

The AWS server-group response on Gate's `/deploymentSnapshot` already exposes `name` / `cluster` / `capacity` / `image` / `buildInfo`, but not the ASG's own tags. Moderne's deploy template stamps `Version=<docker-tag>` onto the ASG at `createServerGroup` time ([`infra/spinnaker/lib/singledeploy.libsonnet:167`](https://github.com/moderneinc/moderne-saas/blob/main/infra/spinnaker/lib/singledeploy.libsonnet#L167)), and that tag is the only place Spinnaker carries the docker image version for an AWS cluster — the AMI is a generic Ubuntu base shared across every service, so the docker version lives on the ASG, not in the image metadata.

Without surfacing the tags, the status dashboard has to backfill `imageVersion` by walking deploy executions for every tenant — i.e. pulling customer-tenant executions just to learn one tag per cell. That bloated the snapshot payload by ~150 KB / ~1.5 s in practice. With tags exposed, the dashboard reads `Version` straight off the SG and the customer-tenant executions are no longer needed for that purpose.

**No new AWS calls, no new caching cost.** Clouddriver's `ClusterCachingAgent` already caches `asg.tags` from `describeAutoScalingGroups` ([code](https://github.com/moderneinc/spinnaker/blob/main/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/provider/agent/ClusterCachingAgent.groovy#L320)) — this is pure projection work in Gate. Each tag is reprojected to `{key, value}` (dropping the `resourceId` / `resourceType` / `propagateAtLaunch` noise the raw AWS shape carries), so the payload grows by ~5–10 short strings per active SG.

## Test plan

- [ ] After deploy, hit `/deploymentSnapshot?applications=…` and confirm each `serverGroups[]` entry has a `tags` array containing the `Version` key/value (and any other ASG tags the deploy template wrote).
- [ ] Verify the existing `image`/`buildInfo`/`launchConfig` projection still passes through for the non-tag image-resolution path (back-compat).
- [ ] Confirm SGs with no tags (defensive — shouldn't happen for our deploys) simply omit the `tags` key rather than emitting an empty array.
