### PR TITLE
clouddriver,gate: actually expose ASG tags on the multi-app serverGroups endpoint

### DIFF
--- a/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
+++ b/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy
@@ -92,6 +92,40 @@ class AmazonServerGroup implements ServerGroup, Serializable {
     return false
   }
 
+  /**
+   * Flatten the AWS ASG tag list into a {key -> value} map for serialization.
+   *
+   * <p>AWS returns ASG tags as a {@code List<TagDescription>} where each entry
+   * has {@code key}, {@code value}, {@code resourceId}, {@code resourceType},
+   * and {@code propagateAtLaunch}. The cache stores those entries as
+   * {@code List<Map>} on {@code asg.tags}. The {@code ServerGroup} interface
+   * exposes a single {@code Map<String, Object> getTags()} contract that
+   * {@code ServerGroupViewModel} reads on the multi-app
+   * {@code /serverGroups?applications=…} endpoint, so without this override
+   * AWS server groups never surface their tags through the batch API.
+   *
+   * <p>Tags carry deploy-time metadata that's useful to dashboards (Moderne's
+   * deploy template writes a {@code Version=<docker-tag>} tag, for example) —
+   * this is the cheapest path to making it readable, since the data is
+   * already cached as part of the standard ClusterCachingAgent flow.
+   */
+  @Override
+  Map<String, Object> getTags() {
+    if (asg == null) return null
+    Object rawTags = asg.get('tags')
+    if (!(rawTags instanceof Collection)) return null
+    Map<String, Object> out = new LinkedHashMap<>()
+    for (Object t : (Collection) rawTags) {
+      if (!(t instanceof Map)) continue
+      Object key = ((Map) t).get('key')
+      Object value = ((Map) t).get('value')
+      if (key != null && value != null) {
+        out.put(key.toString(), value)
+      }
+    }
+    return out.isEmpty() ? null : out
+  }
+
   @Override
   Long getCreatedTime() {
     if (!asg) {

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
@@ -267,24 +267,20 @@ public class DeploymentSnapshotService {
     // docker metadata - the AMI is a generic Ubuntu base, the tag lives only on
     // the ASG itself - so without this projection the dashboard has to backfill
     // imageVersion from the deploy execution, which means pulling executions
-    // for every customer tenant just to learn one tag per cell. Projecting
-    // tags here exposes the data Clouddriver already cached
-    // (`describeAutoScalingGroups` returns tags inline) so callers can read
-    // the version off the SG directly. We strip the propagation/resource-type
-    // metadata each tag carries - only key/value are useful at this layer.
+    // for every customer tenant just to learn one tag per cell.
+    //
+    // Clouddriver's ServerGroupViewModel exposes tags as Map<String, Object>
+    // (see ServerGroup.getTags); we forward that shape verbatim. The previous
+    // List<{key,value}> projection added in #103 was based on the cached AWS
+    // shape and never matched the wire shape Clouddriver actually sends - the
+    // override on AmazonServerGroup.getTags that surfaces the data lives in
+    // this same change.
     Object tags = sg.get("tags");
-    if (tags instanceof List) {
-      List<Map<String, Object>> outTags = new ArrayList<>();
-      for (Object o : (List<?>) tags) {
-        if (!(o instanceof Map)) continue;
-        Map<?, ?> t = (Map<?, ?>) o;
-        Object key = t.get("key");
-        Object value = t.get("value");
-        if (key == null || value == null) continue;
-        Map<String, Object> pt = new LinkedHashMap<>();
-        pt.put("key", key);
-        pt.put("value", value);
-        outTags.add(pt);
+    if (tags instanceof Map) {
+      Map<String, Object> outTags = new LinkedHashMap<>();
+      for (Map.Entry<?, ?> e : ((Map<?, ?>) tags).entrySet()) {
+        if (e.getKey() == null || e.getValue() == null) continue;
+        outTags.put(e.getKey().toString(), e.getValue());
       }
       if (!outTags.isEmpty()) p.put("tags", outTags);
     }


### PR DESCRIPTION
## Summary

- Follow-up to #103. That PR added a Gate-side projection that forwarded `tags` on the multi-app `/serverGroups` response — but **Clouddriver never actually populated the field for AWS server groups**, so the projection was inert. I missed this because I read the `AmazonServerGroup` model's fields ([`asg`, `image`, `buildInfo`, …](https://github.com/moderneinc/spinnaker/blob/main/clouddriver/clouddriver-aws/src/main/groovy/com/netflix/spinnaker/clouddriver/aws/model/AmazonServerGroup.groovy)) without verifying what the batch endpoint's `ServerGroupViewModel` actually serializes.

Two reasons it didn't work:

1. **`ServerGroup.getTags()` is a default `return null`** on the interface, and **`AmazonServerGroup` never overrode it.** So `ServerGroupViewModel`'s constructor (which only writes `tags` when non-null and non-empty) silently omitted it from the wire response.
- 2. The Gate-side projection from #103 was looking for a `List<{key, value}>` shape, but `ServerGroupViewModel.tags` is typed `Map<String, Object>` — so even if Clouddriver populated it, the projection would have dropped it.

This PR fixes both:

- Override `AmazonServerGroup.getTags()` to flatten the cached `asg.tags` (a `List<{key, value, resourceId, resourceType, propagateAtLaunch}>` from the AWS SDK) into the `Map<String, Object>` the `ServerGroup` interface expects. Data is already cached by `ClusterCachingAgent`'s standard `describeAutoScalingGroups` flow — **zero new AWS calls, zero new cache cost.**
- Fix the Gate projection in `DeploymentSnapshotService.projectServerGroup` to accept the `Map<String, Object>` shape that `ServerGroupViewModel` actually sends.

## Test plan

- [ ] Hit `/deploymentSnapshot?applications=...` after deploy and confirm each `serverGroups[]` entry has a `tags` object containing `Version` (and the other ASG tags `singledeploy.libsonnet` writes).
- [ ] Confirm `tags` is absent for SGs that genuinely have no tags (defensive — shouldn't happen for Moderne's deploys).
- [ ] Verify existing `name`/`cluster`/`capacity`/`instances` projection still passes through.
