### PR TITLE
gate: forward a statuses allowlist on the deploymentSnapshot endpoint

### DIFF
--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/controllers/DeploymentSnapshotController.java
@@ -61,7 +61,13 @@ public class DeploymentSnapshotController {
               description =
                   "Per-pipeline-config execution limit (default 10) — caps how many recent executions per pipeline are returned")
           @RequestParam(value = "pipelineLimit", required = false, defaultValue = "10")
-          Integer pipelineLimit) {
+          Integer pipelineLimit,
+      @Parameter(
+              name = "statuses",
+              description =
+                  "Optional comma-separated allowlist of ExecutionStatus values to include (e.g. `RUNNING,TERMINAL,FAILED_CONTINUE,STOPPED`). When set, executions in non-listed statuses are filtered out at the Orca query layer; when omitted, executions in every status are returned. Useful for dashboards that only need to render inflight / failed deploys.")
+          @RequestParam(value = "statuses", required = false)
+          String statusesCsv) {
     List<String> applications =
         Arrays.stream(applicationsCsv.split(","))
             .map(String::trim)
@@ -74,6 +80,8 @@ public class DeploymentSnapshotController {
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(Collectors.toList());
-    return snapshotService.getSnapshot(applications, pipelineNames, pipelineLimit);
+    String statuses =
+        statusesCsv == null || statusesCsv.isBlank() ? null : statusesCsv;
+    return snapshotService.getSnapshot(applications, pipelineNames, pipelineLimit, statuses);
   }
 }

--- a/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
+++ b/gate/gate-web/src/main/java/com/netflix/spinnaker/gate/services/DeploymentSnapshotService.java
@@ -81,7 +81,10 @@ public class DeploymentSnapshotService {
   }
 
   public Snapshot getSnapshot(
-      List<String> applications, List<String> pipelineNames, Integer pipelineLimit) {
+      List<String> applications,
+      List<String> pipelineNames,
+      Integer pipelineLimit,
+      String statuses) {
     Snapshot snapshot = new Snapshot();
     snapshot.apps = new ArrayList<>();
     if (applications == null || applications.isEmpty()) return snapshot;
@@ -123,7 +126,7 @@ public class DeploymentSnapshotService {
                     orcaServiceSelector
                         .select()
                         .getDeploymentSnapshots(
-                            applicationsForOrca, pipelineNamesOrEmpty, null, pipelineLimit)),
+                            applicationsForOrca, pipelineNamesOrEmpty, statuses, pipelineLimit)),
             "orca deploymentSnapshots batch");
 
     CompletableFuture.allOf(sgFuture, pipelinesFuture, execsFuture).join();


### PR DESCRIPTION
## Summary

Orca's `/deploymentSnapshots` already accepts a `statuses` query parameter (a CSV of `ExecutionStatus` values that becomes a WHERE-IN filter on the SQL fetch), but Gate's `/deploymentSnapshot` hard-coded `null` at that slot — so external callers couldn't push the filter down. This PR threads the param through `DeploymentSnapshotController` → `DeploymentSnapshotService` → `OrcaService.getDeploymentSnapshots`.

- The status dashboard's primary win: after #104 surfaced the docker version on the SG itself, the only thing the matrix-load path needs executions for is `inflight` / `bad` cell drift classification + trigger-source override. Neither cares about SUCCEEDED runs. With `statuses=RUNNING,PAUSED,NOT_STARTED,TERMINAL,FAILED_CONTINUE,STOPPED` and `pipelineLimit=1`, Orca returns rows only for the cells that actually had a recent non-success deploy — empty for the rest. That cuts the executions slice of the response from ~180 KB to single-digit KB on a healthy fleet.

Omitting the param preserves the prior behaviour (no status filter), so this is back-compatible with all existing callers.

## Test plan

- [ ] `curl /deploymentSnapshot?applications=foo&pipelineNames=deploy-bar&pipelineLimit=1&statuses=RUNNING,TERMINAL,FAILED_CONTINUE,STOPPED` returns executions only for non-SUCCEEDED latest runs.
- [ ] Verified locally against Orca directly: filtering `deploy-dev,deploy-devaz,deploy-cambridge` returned 3 SUCCEEDED rows unfiltered and 2 TERMINAL rows with the filter applied (cambridge dropped out).
- [ ] Omitting `statuses` still returns all executions up to `limit` (back-compat with #103/#104 callers).
