### PR TITLE
fix(orca): skip SpEL eval of osConfig.customData on createServerGroup

### DIFF
--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/AbstractCloudProviderAwareStage.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/AbstractCloudProviderAwareStage.groovy
@@ -17,13 +17,13 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline
 
 import com.netflix.spinnaker.orca.clouddriver.utils.CloudProviderAware
-import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
+import com.netflix.spinnaker.orca.pipeline.ExpressionAwareStageDefinitionBuilder
 import groovy.util.logging.Slf4j
 
 import javax.annotation.Nonnull
 
 @Slf4j
-abstract class AbstractCloudProviderAwareStage implements StageDefinitionBuilder, CloudProviderAware {
+abstract class AbstractCloudProviderAwareStage extends ExpressionAwareStageDefinitionBuilder implements CloudProviderAware {
   private final String type
 
   AbstractCloudProviderAwareStage(String type) {

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -17,12 +17,14 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageGraphBuilder
 import com.netflix.spinnaker.orca.clouddriver.ForceCacheRefreshAware
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.CheckIfApplicationExistsForServerGroupTask
 import com.netflix.spinnaker.orca.kato.pipeline.strategy.Strategy
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 
 import javax.annotation.Nonnull
 import com.fasterxml.jackson.annotation.JsonProperty
@@ -63,6 +65,20 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage implements Forc
     this.rollbackClusterStage = rollbackClusterStage
     this.destroyServerGroupStage = destroyServerGroupStage
     this.dynamicConfigService = dynamicConfigService
+  }
+
+  @Override
+  boolean processExpressions(
+      @Nonnull StageExecution stage,
+      @Nonnull ContextParameterProcessor contextParameterProcessor,
+      @Nonnull ExpressionEvaluationSummary summary) {
+    Boolean skipExpressionEvaluation =
+        (Boolean) stage.context.getOrDefault("skipExpressionEvaluation", false)
+    if (skipExpressionEvaluation) {
+      processDefaultEntries(stage, contextParameterProcessor, summary, ["osConfig"])
+      return false
+    }
+    return true
   }
 
   @Override

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStage.groovy
@@ -72,9 +72,7 @@ class CreateServerGroupStage extends AbstractDeployStrategyStage implements Forc
       @Nonnull StageExecution stage,
       @Nonnull ContextParameterProcessor contextParameterProcessor,
       @Nonnull ExpressionEvaluationSummary summary) {
-    Boolean skipExpressionEvaluation =
-        (Boolean) stage.context.getOrDefault("skipExpressionEvaluation", false)
-    if (skipExpressionEvaluation) {
+    if (Boolean.TRUE.equals(stage.context.get("skipExpressionEvaluation"))) {
       processDefaultEntries(stage, contextParameterProcessor, summary, ["osConfig"])
       return false
     }

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/pipeline/servergroup/CreateServerGroupStageSpec.groovy
@@ -17,12 +17,14 @@
 package com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup
 
 import com.netflix.spinnaker.kork.dynamicconfig.DynamicConfigService
+import com.netflix.spinnaker.kork.expressions.ExpressionEvaluationSummary
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.clouddriver.FeaturesService
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.strategies.DeployStagePreProcessor
 import com.netflix.spinnaker.orca.clouddriver.utils.TrafficGuard
 import com.netflix.spinnaker.orca.api.pipeline.graph.StageDefinitionBuilder
 import com.netflix.spinnaker.orca.pipeline.model.TaskExecutionImpl
+import com.netflix.spinnaker.orca.pipeline.util.ContextParameterProcessor
 import org.springframework.mock.env.MockEnvironment
 
 import java.util.concurrent.TimeUnit
@@ -157,5 +159,41 @@ class CreateServerGroupStageSpec extends Specification {
       serverGroupName  : "myapplication-stack-v001",
       stageTimeoutMs   : TimeUnit.MINUTES.toMillis(5)
     ]
+  }
+
+  def "processExpressions preserves osConfig.customData verbatim when skipExpressionEvaluation is true"() {
+    given:
+    def summary = new ExpressionEvaluationSummary()
+    def processor = new ContextParameterProcessor()
+    def stage = stage {
+      context = [
+        skipExpressionEvaluation: true,
+        account                 : "moderne-azure",
+        osConfig                : [customData: 'license:\n  private-key: ${cli-license-private-key}\n'],
+      ]
+    }
+
+    when:
+    def shouldContinue = createServerGroupStage.processExpressions(stage, processor, summary)
+
+    then:
+    shouldContinue == false
+    stage.context.osConfig.customData == 'license:\n  private-key: ${cli-license-private-key}\n'
+    summary.failureCount == 0
+  }
+
+  def "processExpressions delegates to generic processing when skipExpressionEvaluation is unset"() {
+    given:
+    def summary = new ExpressionEvaluationSummary()
+    def processor = new ContextParameterProcessor()
+    def stage = stage {
+      context = [account: "aws-prod"]
+    }
+
+    when:
+    def shouldContinue = createServerGroupStage.processExpressions(stage, processor, summary)
+
+    then:
+    shouldContinue == true
   }
 }

--- a/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExpressionAwareStageDefinitionBuilder.java
+++ b/orca/orca-core/src/main/java/com/netflix/spinnaker/orca/pipeline/ExpressionAwareStageDefinitionBuilder.java
@@ -33,14 +33,21 @@ import javax.annotation.Nonnull;
 public abstract class ExpressionAwareStageDefinitionBuilder implements StageDefinitionBuilder {
 
   /**
-   * Allows the stage to process SpEL expression in its own context in a custom way
+   * Allows the stage to process SpEL expression in its own context in a custom way.
+   *
+   * <p>Default implementation returns {@code true}, signaling the caller to apply generic
+   * expression processing to the stage's entire context. Subclasses override to take custom action
+   * — for example, calling {@link #processDefaultEntries} with an excluded-key list to keep certain
+   * fields (cloud-init payloads, raw manifests) verbatim.
    *
    * @return true to continue processing, false to stop generic processing of expressions
    */
-  public abstract boolean processExpressions(
+  public boolean processExpressions(
       @Nonnull StageExecution stage,
       @Nonnull ContextParameterProcessor contextParameterProcessor,
-      @Nonnull ExpressionEvaluationSummary summary);
+      @Nonnull ExpressionEvaluationSummary summary) {
+    return true;
+  }
 
   /**
    * Processes all entries in the stage context that aren't handled in a special way by the stage


### PR DESCRIPTION
## Problem

Every Azure tenant deploy is failing in production with `EL1030E: The operator 'SUBTRACT' is not supported between objects of type 'null' and 'null'`, terminating the createServerGroup stage before clouddriver-azure ever sees the request.

Traced to `orca-queue/.../ExpressionAware.kt#processEntries` (line 135-160): for SpEL-v4 stages, every entry in `stage.context` is fed through `contextParameterProcessor.process` at execution time. For `createServerGroup`, that includes `osConfig.customData` — a raw Azure cloud-init payload carrying Spring property placeholders like `${cli-license-private-key}`. SpEL parses the hyphens as a SUBTRACT chain (`cli - license - private - key`), the operands resolve to null, and `shouldFailOnFailedExpressionEvaluation()` terminates the stage.

The customData field is meant to be opaque — Spring's `PropertyPlaceholderHelper` resolves the placeholders at JVM boot against the per-tenant Secrets-Manager / Key-Vault import the same cloud-init wires up. There is no legitimate reason to SpEL-evaluate it.

## Why v1 SaaS pipelines weren't hit

v1 SaaS deploy pipelines use an `evaluateVariables` "Setup cloudinit" pre-stage that materializes the cloud-init text into a `CLOUD_INIT` variable; the Deploy stage's `customData` is just `${CLOUD_INIT}` — one clean SpEL token. That pattern would seem to fix v2 too, but it doesn't: `EvaluateVariablesStage` runs its own SpEL pass on the variable's value, so any `${secret-name}` placeholders inside would still fail with EL1030E — one stage earlier, not later. v1 escapes the bug because its cloud-init contains zero Spring placeholders (secrets land via a separate `%{}` bootstrap script in `runcmd` before Spring boots). The pre-stage pattern is a payload-staging mechanism, not a SpEL-immunity mechanism; v1's safety comes from the *content* of its customData, not the structure of its pipeline.

## Fix

Mirror `DeployManifestStage`'s opt-in pattern. When the stage context has `skipExpressionEvaluation: true`, `processExpressions` runs `processDefaultEntries` with `osConfig` excluded and returns false (skip generic processing). Otherwise returns true (default: full generic processing — backward-compatible no-op).

Two prerequisite changes enable the override:

- `ExpressionAwareStageDefinitionBuilder.processExpressions` changes from `abstract` to a default `return true;` implementation. Existing subclasses (`DeployManifestStage`, `EvaluateVariablesStage`, `DeployCloudrunManifestStage`) keep their explicit overrides; new subclasses inherit a no-op that matches non-`ExpressionAware` behavior.
- `AbstractCloudProviderAwareStage` extends `ExpressionAwareStageDefinitionBuilder` instead of implementing `StageDefinitionBuilder` directly. The parent class already implements `StageDefinitionBuilder` transitively, so the contract is unchanged for every subclass.

Net: 4 files, +66 / −5 lines.

## Trade-offs

- **Opt-in, not unconditional.** Matches the `DeployManifestStage.skipExpressionEvaluation` precedent and avoids subtle behavior changes for setups that legitimately put SpEL inside cluster definitions. Callers that hit the EL1030E issue must set the flag explicitly on the deploy stage (one-liner in their pipeline generator).
- **Single excluded key (`osConfig`).** Covers the Azure path; AWS already base64-encodes `userData`, so it was never SpEL-toxic. If a future cloud provider adds a similar payload field, it can be added to the exclude list.
- **Returning to the abstract base contract.** Subclasses that previously inherited "must implement `processExpressions`" now inherit a working default. This is forward-compatible (overrides still work) and removes an obligation that wasn't load-bearing — `processExpressions` was always advisory, never required for correctness.

## Test plan

- [x] `./gradlew :orca:orca-clouddriver:test --tests "*CreateServerGroupStageSpec*"` — 15/15 pass, including two new tests covering the opt-in path and the default-passthrough path.
- [x] `./gradlew :orca:orca-clouddriver:test :orca:orca-core:test` — full suites pass; no sibling `AbstractCloudProviderAwareStage` subclass regressed by the parent-class change.
- [ ] End-to-end: ship a fork build, redeploy `deploy-devaz` for changesetreader2 with `skipExpressionEvaluation: true` on the createServerGroup stages, verify EL1030E is gone and the cloud-init lands on the VM with placeholders intact for Spring to resolve.