### PR TITLE
fix(azure): AGW frontend lookup + exception propagation in clouddriver-azure

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy
@@ -183,10 +183,13 @@ class AzureNetworkClient extends AzureBaseClient {
         return agItem
       }
     } catch (Exception e) {
-      log.warn("getAppGateway(${resourceGroupName},${appGatewayName}) -> Exception ", e)
+      if (AzureBaseClient.resourceNotFound(e)) {
+        log.warn("getAppGateway(${resourceGroupName},${appGatewayName}) -> not found", e)
+        return null
+      }
+      log.error("getAppGateway(${resourceGroupName},${appGatewayName}) failed", e)
+      throw new RuntimeException("getAppGateway(${resourceGroupName},${appGatewayName}) failed: ${e.message}", e)
     }
-
-    null
   }
 
   /**

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -108,7 +108,7 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
     description.vnetResourceGroup = AzureUtilities.getResourceGroupNameFromResourceId(description.subnetResourceId)
     description.hasNewSubnet = appGateway.tags()?.hasNewSubnet
 
-    description.publicIpName = AzureUtilities.getNameFromResourceId(appGateway?.frontendIpConfigurations().first().publicIpAddress().id())
+    description.publicIpName = AzureUtilities.getNameFromResourceId(appGateway?.frontendIpConfigurations()?.find { it.publicIpAddress() != null }?.publicIpAddress()?.id())
     description.createdTime = appGateway.tags()?.createdTime?.toLong()
     description.tags = appGateway.tags() ?: [:]
     description.region = appGateway.location()

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClientSpec.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2024 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.client
+
+import com.azure.core.http.HttpResponse
+import com.azure.core.management.exception.ManagementException
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import org.mockito.invocation.InvocationOnMock
+import spock.lang.Specification
+
+/**
+ * Tests for AzureNetworkClient.getAppGateway exception-handling logic.
+ *
+ * AzureNetworkClient requires real Azure credentials at construction time, so we
+ * allocate an instance via Unsafe (bypassing the constructor) and then use
+ * Mockito.mockStatic to intercept the static AzureBaseClient.executeOp method.
+ */
+class AzureNetworkClientSpec extends Specification {
+
+  static final String RESOURCE_GROUP = "my-rg"
+  static final String AGW_NAME = "myapp-main-v001"
+
+  /**
+   * Create a ManagementException that fakes a given HTTP status code.
+   */
+  private static ManagementException managementExceptionWithStatus(int statusCode) {
+    def httpResponse = Mockito.mock(HttpResponse)
+    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
+    new ManagementException("Simulated ${statusCode}", httpResponse)
+  }
+
+  /**
+   * Allocate an AzureNetworkClient without running AzureBaseClient's constructor
+   * (which would try to contact Azure). The azure field is left null but that is
+   * fine because executeOp will be mocked out before getAppGateway calls it.
+   */
+  private static AzureNetworkClient allocateClient() {
+    def f = sun.misc.Unsafe.getDeclaredField("theUnsafe")
+    f.accessible = true
+    def unsafe = f.get(null) as sun.misc.Unsafe
+    unsafe.allocateInstance(AzureNetworkClient) as AzureNetworkClient
+  }
+
+  def 'getAppGateway returns null for a 404 ManagementException'() {
+    given:
+    def client = allocateClient()
+    def notFoundEx = managementExceptionWithStatus(HttpURLConnection.HTTP_NOT_FOUND)
+
+    MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
+    staticMock.when({
+      AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong())
+    }).thenThrow(notFoundEx)
+    // also stub the single-arg overload
+    staticMock.when({
+      AzureBaseClient.executeOp(Mockito.any(Closure))
+    }).thenThrow(notFoundEx)
+    staticMock.when({
+      AzureBaseClient.resourceNotFound(notFoundEx)
+    }).thenReturn(true)
+
+    when:
+    def result = client.getAppGateway(RESOURCE_GROUP, AGW_NAME)
+
+    then: '404 → null returned, no exception propagated'
+    result == null
+
+    cleanup:
+    staticMock.close()
+  }
+
+  def 'getAppGateway rethrows a non-404 exception with resource group and AGW name in the message'() {
+    given:
+    def client = allocateClient()
+    def cause = new RuntimeException("simulated NPE in description builder")
+
+    MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
+    staticMock.when({
+      AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong())
+    }).thenThrow(cause)
+    staticMock.when({
+      AzureBaseClient.executeOp(Mockito.any(Closure))
+    }).thenThrow(cause)
+    staticMock.when({
+      AzureBaseClient.resourceNotFound(cause)
+    }).thenReturn(false)
+
+    when:
+    client.getAppGateway(RESOURCE_GROUP, AGW_NAME)
+
+    then: 'a RuntimeException wrapping the original cause is rethrown'
+    def ex = thrown(RuntimeException)
+    ex.cause.is(cause)
+    ex.message.contains(RESOURCE_GROUP)
+    ex.message.contains(AGW_NAME)
+
+    cleanup:
+    staticMock.close()
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model
+
+import com.azure.core.management.SubResource
+import com.azure.resourcemanager.network.fluent.models.ApplicationGatewayInner
+import com.azure.resourcemanager.network.fluent.models.ApplicationGatewayIpConfigurationInner
+import com.azure.resourcemanager.network.models.ApplicationGatewayFrontendIpConfiguration
+import com.azure.resourcemanager.network.models.ApplicationGatewaySku
+import com.azure.resourcemanager.network.models.ApplicationGatewaySkuName
+import com.azure.resourcemanager.network.models.ApplicationGatewayTier
+import org.mockito.Mockito
+import spock.lang.Specification
+
+class AzureAppGatewayDescriptionSpec extends Specification {
+
+  static final String RESOURCE_GROUP = "my-rg"
+  static final String AGW_NAME = "myapp-main-v001"
+  static final String AGW_ID = "/subscriptions/sub1/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Network/applicationGateways/${AGW_NAME}"
+  static final String PUBLIC_IP_ID = "/subscriptions/sub1/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Network/publicIPAddresses/myapp-pip"
+  static final String SUBNET_ID = "/subscriptions/sub1/resourceGroups/${RESOURCE_GROUP}/providers/Microsoft.Network/virtualNetworks/myapp-vnet/subnets/default"
+
+  /**
+   * Build a minimal ApplicationGatewayInner mock with the required fields for
+   * getDescriptionForAppGateway, arranging frontendIpConfigurations so that the
+   * private frontend (null publicIpAddress) comes first in iteration order.
+   * This mirrors the real Azure API behaviour where lex-sorted names place
+   * "frontend-private" before "frontend-public".
+   */
+  private ApplicationGatewayInner buildAgwWithPrivateFrontendFirst() {
+    def agw = Mockito.mock(ApplicationGatewayInner)
+
+    // core identity
+    Mockito.when(agw.name()).thenReturn(AGW_NAME)
+    Mockito.when(agw.id()).thenReturn(AGW_ID)
+    Mockito.when(agw.location()).thenReturn("westus")
+    Mockito.when(agw.tags()).thenReturn([appName: "myapp", stack: "main", detail: null,
+                                         cluster: null, trafficEnabledSG: null,
+                                         hasNewSubnet: null, createdTime: null])
+
+    // sku
+    def sku = new ApplicationGatewaySku()
+      .withName(ApplicationGatewaySkuName.STANDARD_SMALL)
+      .withTier(ApplicationGatewayTier.STANDARD)
+    Mockito.when(agw.sku()).thenReturn(sku)
+
+    // routing rules null so the ?.first() safe-call short-circuits rather than blowing up on empty list
+    Mockito.when(agw.requestRoutingRules()).thenReturn(null)
+    Mockito.when(agw.backendAddressPools()).thenReturn([])
+    Mockito.when(agw.probes()).thenReturn([])
+
+    // gateway IP config (subnet reference)
+    def subnetRef = new SubResource().withId(SUBNET_ID)
+    def ipConfigInner = Mockito.mock(ApplicationGatewayIpConfigurationInner)
+    Mockito.when(ipConfigInner.subnet()).thenReturn(subnetRef)
+    Mockito.when(agw.gatewayIpConfigurations()).thenReturn([ipConfigInner])
+
+    // frontend IP configurations: private first (no publicIpAddress), public second
+    // Azure returns these in name-lexicographic order; "frontend-private" sorts before "frontend-public"
+    def privateFrontend = new ApplicationGatewayFrontendIpConfiguration()
+      .withName("frontend-private")
+      // publicIpAddress intentionally NOT set → publicIpAddress() returns null
+
+    def publicIpRef = new SubResource().withId(PUBLIC_IP_ID)
+    def publicFrontend = new ApplicationGatewayFrontendIpConfiguration()
+      .withName("frontend-public")
+      .withPublicIpAddress(publicIpRef)
+
+    Mockito.when(agw.frontendIpConfigurations()).thenReturn([privateFrontend, publicFrontend])
+
+    agw
+  }
+
+  def 'getDescriptionForAppGateway picks the public frontend when private frontend comes first'() {
+    given: 'a multi-frontend AGW where the private frontend is listed before the public one'
+    def agw = buildAgwWithPrivateFrontendFirst()
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'publicIpName resolves to the resource name from the public frontend IP'
+    description.publicIpName == "myapp-pip"
+  }
+}


### PR DESCRIPTION
- Stacked on #106. Address the deploy-blocking root cause documented in moderneinc/moderne-saas#1017.

## Fix 1 — Use `find { publicIpAddress != null }` for AGW `publicIpName` lookup

**File:** `clouddriver-azure/.../AzureAppGatewayDescription.groovy`

Azure returns `frontendIpConfigurations` in name-lexicographic order. On multi-frontend AGWs (public + private), `.first()` deterministically returns the private frontend whose `publicIpAddress()` is null, causing an NPE on `.id()` that surfaces downstream as "Invalid Application Gateway was selected".

The fix uses `.find { it.publicIpAddress() != null }` to select the public frontend regardless of ordering, and chains `?.` throughout for null-safety. This mirrors the intent of `defaultPublicFrontend()` already used at three call sites in the sibling `AzureNetworkClient.groovy`.

**Test:** `AzureAppGatewayDescriptionSpec` — one new test that constructs an `ApplicationGatewayInner` mock with `frontend-private` listed first (null `publicIpAddress`) and `frontend-public` second. Confirmed RED (NPE on `.id()`) before fix, GREEN after.

## Fix 2 — Surface non-404 exceptions from `getAppGateway` instead of swallowing them

**File:** `clouddriver-azure/.../AzureNetworkClient.groovy`

The previous `catch (Exception e) { log.warn(...) }` block swallowed all exceptions — NPEs in description-building, throttling exhaustion, SDK bugs — and returned null. Callers saw only "Invalid Application Gateway was selected" with the real cause buried in logs.

The fix distinguishes:
- **404 (`resourceNotFound`)**: log WARN, return null (legitimate "AGW doesn't exist")
- **Anything else**: log ERROR, rethrow as `RuntimeException` wrapping the original cause so the kato task error includes the actual diagnostic

**Test:** `AzureNetworkClientSpec` — two new tests using `Mockito.mockStatic(AzureBaseClient)` and `Unsafe.allocateInstance` to bypass Azure SDK initialization:
- Case A (404): returns null, no exception
- Case B (generic RuntimeException): rethrows with cause + resource group/AGW name in message

Confirmed Case B RED (no exception thrown) before fix, GREEN after.

## Notes

- Both tests confirmed RED then GREEN via TDD
- `clouddriver-azure:test` runs clean with both fixes; 26 pre-existing failures exist on the base branch (unrelated to this PR)
- After #106 lands, this PR's base should be re-targeted to `main`

## Test plan

- [ ] `./gradlew :clouddriver:clouddriver-azure:test --tests "com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model.AzureAppGatewayDescriptionSpec"` passes
- [ ] `./gradlew :clouddriver:clouddriver-azure:test --tests "com.netflix.spinnaker.clouddriver.azure.client.AzureNetworkClientSpec"` passes
- [ ] `./gradlew :clouddriver:clouddriver-azure:test` passes (excluding pre-existing failures)
- [ ] Deploy to staging and exercise an Azure AGW deploy with a multi-frontend gateway (public + private) to confirm no "Invalid Application Gateway was selected" error