### PR TITLE
fix(azure): defensive null-safety in clouddriver-azure description builders

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -102,7 +102,6 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
     }
 
     // We only support one subnet so we can just retrieve the first one.
-    // Use find{} instead of first() to avoid NoSuchElementException on an empty list.
     description.subnetResourceId = appGateway?.gatewayIpConfigurations()?.find { it != null }?.subnet()?.id()
     description.subnet = AzureUtilities.getNameFromResourceId(description.subnetResourceId)
     description.vnet = AzureUtilities.getResourceNameFromId(description.subnetResourceId)
@@ -116,16 +115,13 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
 
     // Use ?.each so a null requestRoutingRules() is treated as an empty collection.
     appGateway.requestRoutingRules()?.each { rule ->
-      // rule.httpListener() may be null; skip the rule rather than NPE inside find{}.
       def listenerRef = rule.httpListener()
       def httpListener = listenerRef != null ? appGateway.httpListeners()?.find { it.id() == listenerRef.id() } : null
       // Only HTTP protocol types are supported for now; ignore any other probes
       // TODO: add support for other protocols (if needed)
       if (httpListener && httpListener.protocol() == ApplicationGatewayProtocol.HTTP) {
-        // httpListener.frontendPort() may be null; guard before calling .id() inside find{}.
         def frontendPortRef = httpListener.frontendPort()
         def frontendPort = frontendPortRef != null ? appGateway.frontendPorts()?.find { it.id() == frontendPortRef.id() } : null
-        // rule.backendHttpSettings() may be null; guard before calling .id() inside find{}.
         def backendSettingsRef = rule.backendHttpSettings()
         def backendHttpSettingsCollection = backendSettingsRef != null ? appGateway.backendHttpSettingsCollection()?.find { it.id() == backendSettingsRef.id() } : null
         if (frontendPort && backendHttpSettingsCollection) {

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescription.groovy
@@ -101,8 +101,9 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
       if (bap.name() != AzureAppGatewayResourceTemplate.defaultAppGatewayBeAddrPoolName) description.serverGroups << bap.name()
     }
 
-    // We only support one subnet so we can just retrieve the first one
-    description.subnetResourceId = appGateway?.gatewayIpConfigurations()?.first()?.subnet()?.id()
+    // We only support one subnet so we can just retrieve the first one.
+    // Use find{} instead of first() to avoid NoSuchElementException on an empty list.
+    description.subnetResourceId = appGateway?.gatewayIpConfigurations()?.find { it != null }?.subnet()?.id()
     description.subnet = AzureUtilities.getNameFromResourceId(description.subnetResourceId)
     description.vnet = AzureUtilities.getResourceNameFromId(description.subnetResourceId)
     description.vnetResourceGroup = AzureUtilities.getResourceGroupNameFromResourceId(description.subnetResourceId)
@@ -113,13 +114,20 @@ class AzureAppGatewayDescription extends AzureResourceOpsDescription {
     description.tags = appGateway.tags() ?: [:]
     description.region = appGateway.location()
 
-    appGateway.requestRoutingRules().each { rule ->
-      def httpListener = appGateway.httpListeners().find { it.id() == rule.httpListener().id() }
+    // Use ?.each so a null requestRoutingRules() is treated as an empty collection.
+    appGateway.requestRoutingRules()?.each { rule ->
+      // rule.httpListener() may be null; skip the rule rather than NPE inside find{}.
+      def listenerRef = rule.httpListener()
+      def httpListener = listenerRef != null ? appGateway.httpListeners()?.find { it.id() == listenerRef.id() } : null
       // Only HTTP protocol types are supported for now; ignore any other probes
       // TODO: add support for other protocols (if needed)
       if (httpListener && httpListener.protocol() == ApplicationGatewayProtocol.HTTP) {
-        def frontendPort = appGateway.frontendPorts()?.find { it.id() == httpListener.frontendPort().id() }
-        def backendHttpSettingsCollection = appGateway.backendHttpSettingsCollection()?.find { it.id() == rule.backendHttpSettings().id()}
+        // httpListener.frontendPort() may be null; guard before calling .id() inside find{}.
+        def frontendPortRef = httpListener.frontendPort()
+        def frontendPort = frontendPortRef != null ? appGateway.frontendPorts()?.find { it.id() == frontendPortRef.id() } : null
+        // rule.backendHttpSettings() may be null; guard before calling .id() inside find{}.
+        def backendSettingsRef = rule.backendHttpSettings()
+        def backendHttpSettingsCollection = backendSettingsRef != null ? appGateway.backendHttpSettingsCollection()?.find { it.id() == backendSettingsRef.id() } : null
         if (frontendPort && backendHttpSettingsCollection) {
           description.loadBalancingRules.add(
             new AzureAppGatewayRule(

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescription.groovy
@@ -117,7 +117,7 @@ class AzureLoadBalancerDescription extends AzureResourceOpsDescription {
       r.probeName = AzureUtilities.getNameFromResourceId(rule?.probe()?.id()) ?: "not-assigned"
       r.persistence = rule.loadDistribution()
       r.idleTimeout = rule.idleTimeoutInMinutes()
-      description.trafficEnabledSG = AzureUtilities.getNameFromResourceId(rule.backendAddressPool().id())
+      description.trafficEnabledSG = AzureUtilities.getNameFromResourceId(rule.backendAddressPool()?.id())
 
       if (rule.protocol() == TransportProtocol.UDP) {
         r.protocol = AzureLoadBalancingRule.AzureLoadBalancingRulesType.UDP

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureServerGroupDescription.groovy
@@ -238,7 +238,9 @@ class AzureServerGroupDescription extends AzureResourceOpsDescription implements
 
 
     azureSG.region = scaleSet.location()
-    azureSG.upgradePolicy = getPolicyFromMode(scaleSet.upgradePolicy().mode().name())
+    // upgradePolicy is optional in the Azure API; default to Manual when absent.
+    def upgradeMode = scaleSet.upgradePolicy()?.mode()?.name()
+    azureSG.upgradePolicy = upgradeMode ? getPolicyFromMode(upgradeMode) : UpgradePolicy.Manual
 
     def termProfile = scaleSet.virtualMachineProfile()?.scheduledEventsProfile()?.terminateNotificationProfile()
     if (termProfile)

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
@@ -101,10 +101,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.publicIpName == "myapp-pip"
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: .first() on empty gatewayIpConfigurations list throws
-  //         NoSuchElementException.  subnetResourceId must stay null.
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway tolerates empty gatewayIpConfigurations'() {
     given: 'an AGW whose gatewayIpConfigurations list is empty'
     def agw = buildMinimalAgw()
@@ -118,10 +114,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.subnetResourceId == null
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: null requestRoutingRules() — .each on null throws NPE.
-  //         Already partially handled at line 89 but line 116 is unguarded.
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway tolerates null requestRoutingRules'() {
     given: 'an AGW that returns null for requestRoutingRules'
     def agw = buildMinimalAgw()
@@ -135,10 +127,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: rule.httpListener() is null — .id() on null throws NPE when
-  // httpListeners list is non-empty (closure body is evaluated).
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway skips routing rule when httpListener reference is null'() {
     given: 'a rule with no httpListener reference but a non-empty listeners list'
     def agw = buildMinimalAgw()
@@ -150,10 +138,10 @@ class AzureAppGatewayDescriptionSpec extends Specification {
 
     def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
     Mockito.when(rule.name()).thenReturn("rule1")
-    Mockito.when(rule.httpListener()).thenReturn(null)  // null reference → NPE on .id() inside find{}
+    Mockito.when(rule.httpListener()).thenReturn(null)
 
     Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
-    Mockito.when(agw.httpListeners()).thenReturn([someListener])  // non-empty so closure IS evaluated
+    Mockito.when(agw.httpListeners()).thenReturn([someListener])
     Mockito.when(agw.frontendPorts()).thenReturn([])
     Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([])
 
@@ -165,9 +153,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: httpListeners() is null — .find on null throws NPE.
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway tolerates null httpListeners'() {
     given: 'an AGW with a routing rule but null httpListeners'
     def agw = buildMinimalAgw()
@@ -186,10 +171,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: httpListener.frontendPort() is null — .id() throws NPE when the
-  // frontendPorts list is non-empty (closure body IS evaluated).
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway skips routing rule when frontendPort reference is null'() {
     given: 'a matched HTTP listener whose frontendPort reference is null but frontendPorts list is non-empty'
     def agw = buildMinimalAgw()
@@ -199,9 +180,8 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     def listener = new ApplicationGatewayHttpListener()
       .withId(listenerId)
       .withProtocol(ApplicationGatewayProtocol.HTTP)
-      // frontendPort intentionally NOT set → frontendPort() returns null → NPE on .id() inside find{}
+      // frontendPort intentionally not set → frontendPort() returns null
 
-    // A non-null frontend port object to force closure evaluation
     def someFrontendPort = new ApplicationGatewayFrontendPort()
       .withId("/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/frontendPorts/port80")
       .withPort(80)
@@ -212,7 +192,7 @@ class AzureAppGatewayDescriptionSpec extends Specification {
 
     Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
     Mockito.when(agw.httpListeners()).thenReturn([listener])
-    Mockito.when(agw.frontendPorts()).thenReturn([someFrontendPort])  // non-empty so closure IS evaluated
+    Mockito.when(agw.frontendPorts()).thenReturn([someFrontendPort])
     Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([])
 
     when:
@@ -223,10 +203,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: rule.backendHttpSettings() is null — .id() throws NPE when the
-  // backendHttpSettingsCollection is non-empty (closure body IS evaluated).
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway skips routing rule when backendHttpSettings reference is null'() {
     given: 'a matched HTTP listener with valid frontendPort but null backendHttpSettings on the rule'
     def agw = buildMinimalAgw()
@@ -244,7 +220,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
       .withId(frontendPortId)
       .withPort(80)
 
-    // A non-null backendHttpSettings object in the collection to force closure evaluation
     def someSettingsId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/backendHttpSettingsCollection/settings1"
     def someSettings = new ApplicationGatewayBackendHttpSettings()
       .withId(someSettingsId)
@@ -253,12 +228,12 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
     Mockito.when(rule.name()).thenReturn("rule1")
     Mockito.when(rule.httpListener()).thenReturn(listenerRef)
-    Mockito.when(rule.backendHttpSettings()).thenReturn(null)  // null → NPE on .id() inside find{}
+    Mockito.when(rule.backendHttpSettings()).thenReturn(null)
 
     Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
     Mockito.when(agw.httpListeners()).thenReturn([listener])
     Mockito.when(agw.frontendPorts()).thenReturn([frontendPort])
-    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([someSettings])  // non-empty so closure IS evaluated
+    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([someSettings])
 
     when:
     def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
@@ -268,9 +243,6 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Happy path: a fully-formed routing rule is mapped to a loadBalancingRule.
-  // -------------------------------------------------------------------------
   def 'getDescriptionForAppGateway maps a complete HTTP routing rule to a loadBalancingRule'() {
     given: 'a fully-populated AGW with one HTTP routing rule'
     def agw = buildMinimalAgw()
@@ -314,11 +286,8 @@ class AzureAppGatewayDescriptionSpec extends Specification {
     description.loadBalancingRules[0].backendPort == 8080
   }
 
-  // -------------------------------------------------------------------------
-  // Helper: a minimal AGW mock with no routing rules (null) and a valid
-  // gatewayIpConfigurations list with one element.  Tests that need to vary
-  // these properties set them after calling this helper.
-  // -------------------------------------------------------------------------
+  // Helper: minimal AGW mock with no routing rules and a valid gatewayIpConfigurations list.
+  // Tests that need to vary these properties override them after calling this helper.
   private ApplicationGatewayInner buildMinimalAgw() {
     def agw = Mockito.mock(ApplicationGatewayInner)
     Mockito.when(agw.name()).thenReturn(AGW_NAME)

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/appgateway/model/AzureAppGatewayDescriptionSpec.groovy
@@ -19,7 +19,12 @@ package com.netflix.spinnaker.clouddriver.azure.resources.appgateway.model
 import com.azure.core.management.SubResource
 import com.azure.resourcemanager.network.fluent.models.ApplicationGatewayInner
 import com.azure.resourcemanager.network.fluent.models.ApplicationGatewayIpConfigurationInner
+import com.azure.resourcemanager.network.fluent.models.ApplicationGatewayRequestRoutingRuleInner
+import com.azure.resourcemanager.network.models.ApplicationGatewayBackendHttpSettings
 import com.azure.resourcemanager.network.models.ApplicationGatewayFrontendIpConfiguration
+import com.azure.resourcemanager.network.models.ApplicationGatewayFrontendPort
+import com.azure.resourcemanager.network.models.ApplicationGatewayHttpListener
+import com.azure.resourcemanager.network.models.ApplicationGatewayProtocol
 import com.azure.resourcemanager.network.models.ApplicationGatewaySku
 import com.azure.resourcemanager.network.models.ApplicationGatewaySkuName
 import com.azure.resourcemanager.network.models.ApplicationGatewayTier
@@ -94,5 +99,250 @@ class AzureAppGatewayDescriptionSpec extends Specification {
 
     then: 'publicIpName resolves to the resource name from the public frontend IP'
     description.publicIpName == "myapp-pip"
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: .first() on empty gatewayIpConfigurations list throws
+  //         NoSuchElementException.  subnetResourceId must stay null.
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway tolerates empty gatewayIpConfigurations'() {
+    given: 'an AGW whose gatewayIpConfigurations list is empty'
+    def agw = buildMinimalAgw()
+    Mockito.when(agw.gatewayIpConfigurations()).thenReturn([])
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and subnetResourceId is null'
+    noExceptionThrown()
+    description.subnetResourceId == null
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: null requestRoutingRules() — .each on null throws NPE.
+  //         Already partially handled at line 89 but line 116 is unguarded.
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway tolerates null requestRoutingRules'() {
+    given: 'an AGW that returns null for requestRoutingRules'
+    def agw = buildMinimalAgw()
+    Mockito.when(agw.requestRoutingRules()).thenReturn(null)
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and loadBalancingRules is empty'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: rule.httpListener() is null — .id() on null throws NPE when
+  // httpListeners list is non-empty (closure body is evaluated).
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway skips routing rule when httpListener reference is null'() {
+    given: 'a rule with no httpListener reference but a non-empty listeners list'
+    def agw = buildMinimalAgw()
+
+    def someListenerId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/httpListeners/listener1"
+    def someListener = new ApplicationGatewayHttpListener()
+      .withId(someListenerId)
+      .withProtocol(ApplicationGatewayProtocol.HTTP)
+
+    def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.httpListener()).thenReturn(null)  // null reference → NPE on .id() inside find{}
+
+    Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
+    Mockito.when(agw.httpListeners()).thenReturn([someListener])  // non-empty so closure IS evaluated
+    Mockito.when(agw.frontendPorts()).thenReturn([])
+    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([])
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and no rule is added'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: httpListeners() is null — .find on null throws NPE.
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway tolerates null httpListeners'() {
+    given: 'an AGW with a routing rule but null httpListeners'
+    def agw = buildMinimalAgw()
+    def listenerRef = new SubResource().withId("/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/httpListeners/listener1")
+    def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.httpListener()).thenReturn(listenerRef)
+    Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
+    Mockito.when(agw.httpListeners()).thenReturn(null)
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and no rule is added'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: httpListener.frontendPort() is null — .id() throws NPE when the
+  // frontendPorts list is non-empty (closure body IS evaluated).
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway skips routing rule when frontendPort reference is null'() {
+    given: 'a matched HTTP listener whose frontendPort reference is null but frontendPorts list is non-empty'
+    def agw = buildMinimalAgw()
+    def listenerId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/httpListeners/listener1"
+    def listenerRef = new SubResource().withId(listenerId)
+
+    def listener = new ApplicationGatewayHttpListener()
+      .withId(listenerId)
+      .withProtocol(ApplicationGatewayProtocol.HTTP)
+      // frontendPort intentionally NOT set → frontendPort() returns null → NPE on .id() inside find{}
+
+    // A non-null frontend port object to force closure evaluation
+    def someFrontendPort = new ApplicationGatewayFrontendPort()
+      .withId("/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/frontendPorts/port80")
+      .withPort(80)
+
+    def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.httpListener()).thenReturn(listenerRef)
+
+    Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
+    Mockito.when(agw.httpListeners()).thenReturn([listener])
+    Mockito.when(agw.frontendPorts()).thenReturn([someFrontendPort])  // non-empty so closure IS evaluated
+    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([])
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and no rule is added'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: rule.backendHttpSettings() is null — .id() throws NPE when the
+  // backendHttpSettingsCollection is non-empty (closure body IS evaluated).
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway skips routing rule when backendHttpSettings reference is null'() {
+    given: 'a matched HTTP listener with valid frontendPort but null backendHttpSettings on the rule'
+    def agw = buildMinimalAgw()
+    def listenerId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/httpListeners/listener1"
+    def listenerRef = new SubResource().withId(listenerId)
+    def frontendPortId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/frontendPorts/port80"
+    def frontendPortRef = new SubResource().withId(frontendPortId)
+
+    def listener = new ApplicationGatewayHttpListener()
+      .withId(listenerId)
+      .withProtocol(ApplicationGatewayProtocol.HTTP)
+      .withFrontendPort(frontendPortRef)
+
+    def frontendPort = new ApplicationGatewayFrontendPort()
+      .withId(frontendPortId)
+      .withPort(80)
+
+    // A non-null backendHttpSettings object in the collection to force closure evaluation
+    def someSettingsId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/backendHttpSettingsCollection/settings1"
+    def someSettings = new ApplicationGatewayBackendHttpSettings()
+      .withId(someSettingsId)
+      .withPort(8080)
+
+    def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.httpListener()).thenReturn(listenerRef)
+    Mockito.when(rule.backendHttpSettings()).thenReturn(null)  // null → NPE on .id() inside find{}
+
+    Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
+    Mockito.when(agw.httpListeners()).thenReturn([listener])
+    Mockito.when(agw.frontendPorts()).thenReturn([frontendPort])
+    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([someSettings])  // non-empty so closure IS evaluated
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'no exception is thrown and no rule is added'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Happy path: a fully-formed routing rule is mapped to a loadBalancingRule.
+  // -------------------------------------------------------------------------
+  def 'getDescriptionForAppGateway maps a complete HTTP routing rule to a loadBalancingRule'() {
+    given: 'a fully-populated AGW with one HTTP routing rule'
+    def agw = buildMinimalAgw()
+    def listenerId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/httpListeners/listener1"
+    def listenerRef = new SubResource().withId(listenerId)
+    def frontendPortId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/frontendPorts/port80"
+    def frontendPortRef = new SubResource().withId(frontendPortId)
+    def backendSettingsId = "/subscriptions/s/resourceGroups/rg/providers/Microsoft.Network/applicationGateways/agw/backendHttpSettingsCollection/settings1"
+    def backendSettingsRef = new SubResource().withId(backendSettingsId)
+
+    def listener = new ApplicationGatewayHttpListener()
+      .withId(listenerId)
+      .withProtocol(ApplicationGatewayProtocol.HTTP)
+      .withFrontendPort(frontendPortRef)
+
+    def frontendPort = new ApplicationGatewayFrontendPort()
+      .withId(frontendPortId)
+      .withPort(80)
+
+    def backendSettings = new ApplicationGatewayBackendHttpSettings()
+      .withId(backendSettingsId)
+      .withPort(8080)
+
+    def rule = Mockito.mock(ApplicationGatewayRequestRoutingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.httpListener()).thenReturn(listenerRef)
+    Mockito.when(rule.backendHttpSettings()).thenReturn(backendSettingsRef)
+
+    Mockito.when(agw.requestRoutingRules()).thenReturn([rule])
+    Mockito.when(agw.httpListeners()).thenReturn([listener])
+    Mockito.when(agw.frontendPorts()).thenReturn([frontendPort])
+    Mockito.when(agw.backendHttpSettingsCollection()).thenReturn([backendSettings])
+
+    when:
+    def description = AzureAppGatewayDescription.getDescriptionForAppGateway(agw)
+
+    then: 'one loadBalancingRule is added with the correct ports'
+    description.loadBalancingRules.size() == 1
+    description.loadBalancingRules[0].ruleName == "rule1"
+    description.loadBalancingRules[0].externalPort == 80
+    description.loadBalancingRules[0].backendPort == 8080
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper: a minimal AGW mock with no routing rules (null) and a valid
+  // gatewayIpConfigurations list with one element.  Tests that need to vary
+  // these properties set them after calling this helper.
+  // -------------------------------------------------------------------------
+  private ApplicationGatewayInner buildMinimalAgw() {
+    def agw = Mockito.mock(ApplicationGatewayInner)
+    Mockito.when(agw.name()).thenReturn(AGW_NAME)
+    Mockito.when(agw.id()).thenReturn(AGW_ID)
+    Mockito.when(agw.location()).thenReturn("westus")
+    Mockito.when(agw.tags()).thenReturn([appName: "myapp", stack: "main", detail: null,
+                                         cluster: null, trafficEnabledSG: null,
+                                         hasNewSubnet: null, createdTime: null])
+
+    def sku = new ApplicationGatewaySku()
+      .withName(ApplicationGatewaySkuName.STANDARD_SMALL)
+      .withTier(ApplicationGatewayTier.STANDARD)
+    Mockito.when(agw.sku()).thenReturn(sku)
+
+    def subnetRef = new SubResource().withId(SUBNET_ID)
+    def ipConfigInner = Mockito.mock(ApplicationGatewayIpConfigurationInner)
+    Mockito.when(ipConfigInner.subnet()).thenReturn(subnetRef)
+    Mockito.when(agw.gatewayIpConfigurations()).thenReturn([ipConfigInner])
+
+    Mockito.when(agw.requestRoutingRules()).thenReturn(null)
+    Mockito.when(agw.backendAddressPools()).thenReturn([])
+    Mockito.when(agw.frontendIpConfigurations()).thenReturn([])
+    Mockito.when(agw.probes()).thenReturn([])
+
+    agw
   }
 }

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescriptionSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescriptionSpec.groovy
@@ -31,10 +31,6 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
   static final String LB_NAME = "myapp-main-v001"
   static final String LB_ID = "/subscriptions/sub1/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/${LB_NAME}"
 
-  // -------------------------------------------------------------------------
-  // Hazard: loadBalancingRules() returns null — for-each on null throws NPE
-  // under @CompileStatic (generates Java for-each, not Groovy's null-safe each).
-  // -------------------------------------------------------------------------
   def 'build tolerates null loadBalancingRules'() {
     given: 'a load balancer whose loadBalancingRules() returns null'
     def lb = buildMinimalLb()
@@ -48,9 +44,6 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     description.loadBalancingRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: rule.backendAddressPool() returns null — .id() on null throws NPE.
-  // -------------------------------------------------------------------------
   def 'build tolerates a routing rule with null backendAddressPool'() {
     given: 'a rule that has no backendAddressPool reference'
     def lb = buildMinimalLb()
@@ -61,7 +54,7 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     Mockito.when(rule.probe()).thenReturn(null)
     Mockito.when(rule.loadDistribution()).thenReturn(null)
     Mockito.when(rule.idleTimeoutInMinutes()).thenReturn(4)
-    Mockito.when(rule.backendAddressPool()).thenReturn(null)  // null → NPE on .id()
+    Mockito.when(rule.backendAddressPool()).thenReturn(null)
     Mockito.when(rule.protocol()).thenReturn(TransportProtocol.TCP)
     Mockito.when(lb.loadBalancingRules()).thenReturn([rule])
 
@@ -74,9 +67,6 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     description.trafficEnabledSG == null
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: probes() returns null — for-each on null throws NPE under @CompileStatic.
-  // -------------------------------------------------------------------------
   def 'build tolerates null probes'() {
     given: 'a load balancer whose probes() returns null'
     def lb = buildMinimalLb()
@@ -90,9 +80,6 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     description.probes.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: inboundNatRules() returns null — for-each on null throws NPE.
-  // -------------------------------------------------------------------------
   def 'build tolerates null inboundNatRules'() {
     given: 'a load balancer whose inboundNatRules() returns null'
     def lb = buildMinimalLb()
@@ -106,9 +93,6 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     description.inboundNATRules.isEmpty()
   }
 
-  // -------------------------------------------------------------------------
-  // Happy path: a fully-formed load balancer maps correctly.
-  // -------------------------------------------------------------------------
   def 'build maps a complete load balancer to a description'() {
     given: 'a fully-populated load balancer with one rule, one probe, one NAT rule'
     def lb = buildMinimalLb()
@@ -152,9 +136,7 @@ class AzureLoadBalancerDescriptionSpec extends Specification {
     description.trafficEnabledSG == "myBackendPool"
   }
 
-  // -------------------------------------------------------------------------
   // Helper: minimal LoadBalancerInner mock with empty collections and basic tags.
-  // -------------------------------------------------------------------------
   private LoadBalancerInner buildMinimalLb() {
     def lb = Mockito.mock(LoadBalancerInner)
     Mockito.when(lb.name()).thenReturn(LB_NAME)

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescriptionSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/loadbalancer/model/AzureLoadBalancerDescriptionSpec.groovy
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2024 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.loadbalancer.model
+
+import com.azure.core.management.SubResource
+import com.azure.resourcemanager.network.fluent.models.InboundNatRuleInner
+import com.azure.resourcemanager.network.fluent.models.LoadBalancerInner
+import com.azure.resourcemanager.network.fluent.models.LoadBalancingRuleInner
+import com.azure.resourcemanager.network.fluent.models.ProbeInner
+import com.azure.resourcemanager.network.models.ProbeProtocol
+import com.azure.resourcemanager.network.models.TransportProtocol
+import org.mockito.Mockito
+import spock.lang.Specification
+
+class AzureLoadBalancerDescriptionSpec extends Specification {
+
+  static final String LB_NAME = "myapp-main-v001"
+  static final String LB_ID = "/subscriptions/sub1/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/${LB_NAME}"
+
+  // -------------------------------------------------------------------------
+  // Hazard: loadBalancingRules() returns null — for-each on null throws NPE
+  // under @CompileStatic (generates Java for-each, not Groovy's null-safe each).
+  // -------------------------------------------------------------------------
+  def 'build tolerates null loadBalancingRules'() {
+    given: 'a load balancer whose loadBalancingRules() returns null'
+    def lb = buildMinimalLb()
+    Mockito.when(lb.loadBalancingRules()).thenReturn(null)
+
+    when:
+    def description = AzureLoadBalancerDescription.build(lb)
+
+    then: 'no exception is thrown and loadBalancingRules is empty'
+    noExceptionThrown()
+    description.loadBalancingRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: rule.backendAddressPool() returns null — .id() on null throws NPE.
+  // -------------------------------------------------------------------------
+  def 'build tolerates a routing rule with null backendAddressPool'() {
+    given: 'a rule that has no backendAddressPool reference'
+    def lb = buildMinimalLb()
+    def rule = Mockito.mock(LoadBalancingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.frontendPort()).thenReturn(80)
+    Mockito.when(rule.backendPort()).thenReturn(8080)
+    Mockito.when(rule.probe()).thenReturn(null)
+    Mockito.when(rule.loadDistribution()).thenReturn(null)
+    Mockito.when(rule.idleTimeoutInMinutes()).thenReturn(4)
+    Mockito.when(rule.backendAddressPool()).thenReturn(null)  // null → NPE on .id()
+    Mockito.when(rule.protocol()).thenReturn(TransportProtocol.TCP)
+    Mockito.when(lb.loadBalancingRules()).thenReturn([rule])
+
+    when:
+    def description = AzureLoadBalancerDescription.build(lb)
+
+    then: 'no exception is thrown and the rule is still added (trafficEnabledSG is null)'
+    noExceptionThrown()
+    description.loadBalancingRules.size() == 1
+    description.trafficEnabledSG == null
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: probes() returns null — for-each on null throws NPE under @CompileStatic.
+  // -------------------------------------------------------------------------
+  def 'build tolerates null probes'() {
+    given: 'a load balancer whose probes() returns null'
+    def lb = buildMinimalLb()
+    Mockito.when(lb.probes()).thenReturn(null)
+
+    when:
+    def description = AzureLoadBalancerDescription.build(lb)
+
+    then: 'no exception is thrown and probes is empty'
+    noExceptionThrown()
+    description.probes.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Hazard: inboundNatRules() returns null — for-each on null throws NPE.
+  // -------------------------------------------------------------------------
+  def 'build tolerates null inboundNatRules'() {
+    given: 'a load balancer whose inboundNatRules() returns null'
+    def lb = buildMinimalLb()
+    Mockito.when(lb.inboundNatRules()).thenReturn(null)
+
+    when:
+    def description = AzureLoadBalancerDescription.build(lb)
+
+    then: 'no exception is thrown and inboundNATRules is empty'
+    noExceptionThrown()
+    description.inboundNATRules.isEmpty()
+  }
+
+  // -------------------------------------------------------------------------
+  // Happy path: a fully-formed load balancer maps correctly.
+  // -------------------------------------------------------------------------
+  def 'build maps a complete load balancer to a description'() {
+    given: 'a fully-populated load balancer with one rule, one probe, one NAT rule'
+    def lb = buildMinimalLb()
+
+    def backendPoolRef = new SubResource().withId(
+      "/subscriptions/sub1/resourceGroups/my-rg/providers/Microsoft.Network/loadBalancers/${LB_NAME}/backendAddressPools/myBackendPool")
+    def rule = Mockito.mock(LoadBalancingRuleInner)
+    Mockito.when(rule.name()).thenReturn("rule1")
+    Mockito.when(rule.frontendPort()).thenReturn(80)
+    Mockito.when(rule.backendPort()).thenReturn(8080)
+    Mockito.when(rule.probe()).thenReturn(null)
+    Mockito.when(rule.loadDistribution()).thenReturn(null)
+    Mockito.when(rule.idleTimeoutInMinutes()).thenReturn(4)
+    Mockito.when(rule.backendAddressPool()).thenReturn(backendPoolRef)
+    Mockito.when(rule.protocol()).thenReturn(TransportProtocol.TCP)
+    Mockito.when(lb.loadBalancingRules()).thenReturn([rule])
+
+    def probe = Mockito.mock(ProbeInner)
+    Mockito.when(probe.name()).thenReturn("probe1")
+    Mockito.when(probe.port()).thenReturn(8080)
+    Mockito.when(probe.intervalInSeconds()).thenReturn(10)
+    Mockito.when(probe.numberOfProbes()).thenReturn(3)
+    Mockito.when(probe.requestPath()).thenReturn("/health")
+    Mockito.when(probe.protocol()).thenReturn(ProbeProtocol.HTTP)
+    Mockito.when(lb.probes()).thenReturn([probe])
+
+    def natRule = Mockito.mock(InboundNatRuleInner)
+    Mockito.when(natRule.name()).thenReturn("nat1")
+    Mockito.when(lb.inboundNatRules()).thenReturn([natRule])
+
+    when:
+    def description = AzureLoadBalancerDescription.build(lb)
+
+    then: 'all collections are populated correctly'
+    description.loadBalancingRules.size() == 1
+    description.loadBalancingRules[0].ruleName == "rule1"
+    description.probes.size() == 1
+    description.probes[0].probeName == "probe1"
+    description.inboundNATRules.size() == 1
+    description.inboundNATRules[0].ruleName == "nat1"
+    description.trafficEnabledSG == "myBackendPool"
+  }
+
+  // -------------------------------------------------------------------------
+  // Helper: minimal LoadBalancerInner mock with empty collections and basic tags.
+  // -------------------------------------------------------------------------
+  private LoadBalancerInner buildMinimalLb() {
+    def lb = Mockito.mock(LoadBalancerInner)
+    Mockito.when(lb.name()).thenReturn(LB_NAME)
+    Mockito.when(lb.id()).thenReturn(LB_ID)
+    Mockito.when(lb.location()).thenReturn("westus")
+    Mockito.when(lb.tags()).thenReturn([appName: "myapp", stack: "main", detail: null,
+                                        cluster: null, vnet: null, createdTime: null,
+                                        internal: null])
+    Mockito.when(lb.frontendIpConfigurations()).thenReturn(null)
+    Mockito.when(lb.backendAddressPools()).thenReturn([])
+    Mockito.when(lb.loadBalancingRules()).thenReturn([])
+    Mockito.when(lb.probes()).thenReturn([])
+    Mockito.when(lb.inboundNatRules()).thenReturn([])
+    lb
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
@@ -139,6 +139,25 @@ class AzureServerGroupDescriptionUnitSpec extends Specification {
     description.disabled == false
   }
 
+  // -------------------------------------------------------------------------
+  // Hazard: scaleSet.upgradePolicy() returns null — .mode().name() throws NPE.
+  // A scale set can arrive from the Azure API without an upgrade policy set.
+  // -------------------------------------------------------------------------
+  def 'should tolerate a null upgradePolicy'() {
+    given: 'a scale set with no upgradePolicy'
+    def scaleSet = createBaseScaleSet(["stack": "testStack", "detail": "testDetail",
+                                        "appName": "testScaleSet",
+                                        "cluster": "testScaleSet-testStack-testDetail"], 1)
+    scaleSet.withUpgradePolicy(null)
+
+    when:
+    def description = AzureServerGroupDescription.build(scaleSet)
+
+    then: 'no exception is thrown and upgradePolicy defaults to Manual'
+    noExceptionThrown()
+    description.upgradePolicy == AzureServerGroupDescription.UpgradePolicy.Manual
+  }
+
 
   private static VirtualMachineScaleSetInner createScaleSet() {
     Map<String, String> tags = [ "stack": "testStack",

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/templates/description/AzureServerGroupDescriptionUnitSpec.groovy
@@ -139,10 +139,6 @@ class AzureServerGroupDescriptionUnitSpec extends Specification {
     description.disabled == false
   }
 
-  // -------------------------------------------------------------------------
-  // Hazard: scaleSet.upgradePolicy() returns null — .mode().name() throws NPE.
-  // A scale set can arrive from the Azure API without an upgrade policy set.
-  // -------------------------------------------------------------------------
   def 'should tolerate a null upgradePolicy'() {
     given: 'a scale set with no upgradePolicy'
     def scaleSet = createBaseScaleSet(["stack": "testStack", "detail": "testDetail",


### PR DESCRIPTION
## Summary

- Follows up on #108 (merged) with a broader null-safety sweep across three description-builder methods that shared the same class of bug — unguarded dereferences on objects the Azure API may return as null or absent.

### Hazards fixed

**`AzureAppGatewayDescription.getDescriptionForAppGateway`** (4 hazards)

| Location | Hazard | Fix |
|---|---|---|
| Line 105 | `.first()` on `gatewayIpConfigurations()` throws `NoSuchElementException` on empty list | Changed to `.find { it != null }` |
| Line 116 | `.each` on potentially-null `requestRoutingRules()` | Changed to `?.each` |
| Line 117 | `rule.httpListener().id()` inside `find{}` closure NPEs when `httpListener()` is null | Extract ref, guard with `!= null` before `find{}` |
| Lines 121–122 | `httpListener.frontendPort().id()` and `rule.backendHttpSettings().id()` inside `find{}` closures NPE when either ref is null | Extract both refs, guard each before `find{}` |

**`AzureLoadBalancerDescription.build`** (1 hazard)

| Location | Hazard | Fix |
|---|---|---|
| Line 120 | `rule.backendAddressPool().id()` NPEs when `backendAddressPool()` is null (internal-only rules, partial provisioning) | Changed to `?.id()` |

**`AzureServerGroupDescription.build`** (1 hazard)

| Location | Hazard | Fix |
|---|---|---|
| Line 241 | `scaleSet.upgradePolicy().mode().name()` NPEs when `upgradePolicy()` is null (optional field in the Azure VMSS API) | Changed to `?.mode()?.name()` with a `Manual` fallback |

### Tests added

Each hazard has a dedicated RED→GREEN test:

- `AzureAppGatewayDescriptionSpec`: 7 new tests (4 hazard cases + 1 happy-path routing-rule mapping; 2 tests for already-safe Groovy null-each patterns serve as regression guards)
- `AzureLoadBalancerDescriptionSpec` (new file): 5 tests covering the backendAddressPool NPE, three confirmed-safe for-each patterns, and a full happy-path
- `AzureServerGroupDescriptionUnitSpec`: 1 new test for null `upgradePolicy`

### Drive-by audit

`AzureVirtualNetworkDescription`, `AzureSubnetDescription`, and `AzureSecurityGroupDescription` were reviewed; no builder-method hazards found.

### Test results

`./gradlew :clouddriver:clouddriver-azure:test` — 190 tests, 25 failed (all 25 are pre-existing failures present on `main` before this branch; none introduced here).

- Refs moderneinc/moderne-saas#1017. Closes the remaining null-deref surface identified after #108.