### PR TITLE
fix(azure): correct instance launchTime unit and harden status parsing

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -47,23 +47,23 @@ class AzureInstance implements Instance, Serializable {
     instance.vhd = vm.storageProfile()?.osDisk()?.vhd()?.uri()
 
     vm.instanceView()?.statuses()?.each { status ->
-      def codes = status.code().split('/')
+      def codes = status.code()?.split('/')
+      if (!codes || codes.length < 2) return
       switch (codes[0]) {
         case "ProvisioningState":
-          if (codes[1].toLowerCase() == AzureUtilities.ProvisioningState.SUCCEEDED.toLowerCase()) {
-            instance.launchTime = status.time()?.toEpochSecond()
+          if (codes[1].equalsIgnoreCase(AzureUtilities.ProvisioningState.SUCCEEDED)) {
+            instance.launchTime = status.time()?.toEpochMilli()
           } else {
             instance.healthState = HealthState.Failed
           }
           break
         case "PowerState":
           instance.healthState =
-            codes[1].toLowerCase() == "Running".toLowerCase() ? HealthState.Up : HealthState.Down
+            codes[1].equalsIgnoreCase("Running") ? HealthState.Up : HealthState.Down
           break
         default:
           break
       }
-
     }
 
     // if health extension exists, read its status and update health state
@@ -71,7 +71,7 @@ class AzureInstance implements Instance, Serializable {
       if (extension.type() == APP_HEALTH_EXT_LINUX ||
         extension.type() == APP_HEALTH_EXT_WINDOWS) {
         def substatuses = extension.substatuses()
-        if (substatuses != null) {
+        if (substatuses) {
           def statusLevel = substatuses[0]?.level()
           if (statusLevel == StatusLevelTypes.ERROR) {
             instance.healthState = HealthState.Down


### PR DESCRIPTION
## Summary

- **Root cause**: `AzureInstance.build()` used `toEpochSecond()` when assigning `launchTime`, but the `Instance` interface contract requires milliseconds. A real timestamp like `1,710,498,600` seconds is treated as ~19 days of milliseconds, rendering as `1970-01-21` in the UI.
- **Fix**: Switch to `toEpochMilli()` — consistent with every other cloud provider (AWS, DC/OS, GCP, CloudFoundry, Kubernetes, CloudRun).
- **Hardening** (found during red-team + simplify pass): three pre-existing bugs in the same function, all now fixed:
  - `status.code()` lacked null-safe navigation — NPE if Azure returns a null status code
  - `codes[1]` was accessed without a bounds check — AIOOBE if a status code has no `/` separator
  - `substatuses[0]` was accessed after a null check but not a size check — IOOBE on empty list
  - Replaced redundant `double-toLowerCase()` comparisons with `equalsIgnoreCase()`

## Test plan

- [ ] Deploy to an Azure-backed environment and confirm instance launch times show real dates instead of `1970-01-21`
- [ ] Existing `AzureInstanceSpec` passes (note: it does not assert on `launchTime` — worth adding a test case for that separately)