### PR TITLE
fix(orca): treat empty/missing cluster as success/retry in WaitForClusterDisableTask

### DIFF
--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTask.groovy
@@ -19,7 +19,9 @@ package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.models.StageExecution
 import com.netflix.spinnaker.orca.api.pipeline.TaskResult
+import com.netflix.spinnaker.orca.clouddriver.model.Cluster
 import com.netflix.spinnaker.orca.clouddriver.model.ServerGroup
+import com.netflix.spinnaker.orca.clouddriver.pipeline.cluster.AbstractClusterWideClouddriverOperationStage.ClusterSelection
 import com.netflix.spinnaker.orca.clouddriver.pipeline.servergroup.support.TargetServerGroup
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.ServerGroupCreator
 import com.netflix.spinnaker.orca.clouddriver.tasks.servergroup.WaitForRequiredInstancesDownTask
@@ -54,6 +56,20 @@ class WaitForClusterDisableTask extends AbstractWaitForClusterWideClouddriverTas
     }.collectEntries { serverGroupCreator ->
       return [(serverGroupCreator.cloudProvider): serverGroupCreator.healthProviderName.orElse(null)]
     }
+  }
+
+  @Override
+  protected TaskResult missingClusterResult(StageExecution stage, ClusterSelection clusterSelection) {
+    // Clouddriver cache may transiently show no cluster during a service restart (e.g. Spinnaker
+    // self-deploy). Retry rather than fail; the OverridableTimeoutRetryableTask timeout bounds the loop.
+    return TaskResult.builder(ExecutionStatus.RUNNING).build()
+  }
+
+  @Override
+  protected TaskResult emptyClusterResult(StageExecution stage, ClusterSelection clusterSelection, Cluster cluster) {
+    // No server groups to check means the old cluster was already cleaned up — most commonly by the
+    // red/black strategy's own disable+scaleDown pass that runs before this explicit stage. Treat as done.
+    return TaskResult.SUCCEEDED
   }
 
   @Override

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/WaitForClusterDisableTaskSpec.groovy
@@ -124,7 +124,7 @@ class WaitForClusterDisableTaskSpec extends Specification {
   }
 
   @Unroll
-  def "fails with '#expectedMessage' when clusterData=#clusterData"() {
+  def "returns #expectedStatus when clouddriver returns #clusterDescription"() {
     given:
     def stage = new StageExecutionImpl(PipelineExecutionImpl.newPipeline("orca"), "test", [
         cluster: clusterName,
@@ -133,21 +133,21 @@ class WaitForClusterDisableTaskSpec extends Specification {
             (region): ["$clusterName-v42".toString()]
         ]
     ])
+    stage.startTime = 0L
 
     cloudDriverService.maybeCluster(*_) >> clusterData
     task.cloudDriverService = cloudDriverService
 
     when:
-    task.execute(stage)
+    def result = task.execute(stage)
 
     then:
-    IllegalStateException e = thrown()
-    e.message.startsWith(expectedMessage)
+    result.status == expectedStatus
 
     where:
-    clusterData                                                   || expectedMessage
-    Optional.empty()                                              || 'no cluster details found'
-    Optional.of(new Cluster(name: clusterName, serverGroups: [])) || 'no server groups found'
+    clusterData                                                    | expectedStatus | clusterDescription
+    Optional.empty()                                               | RUNNING        | 'cluster missing (transient cache miss during restart)'
+    Optional.of(new Cluster(name: clusterName, serverGroups: [])) | SUCCEEDED      | 'cluster found with no server groups (already cleaned up by red/black strategy)'
   }
 
   private static Map instance(name, platformHealthState = 'Unknown', extraHealths = []) {


### PR DESCRIPTION
## Summary

- **`emptyClusterResult` → `SUCCEEDED`**: when Clouddriver returns a cluster with no server groups, the old ASG was already cleaned up — most commonly by the red/black strategy's own disable+scaleDown pass that runs before this explicit stage. Nothing left to disable = done. Mirrors the `WaitForClusterShrinkTask` pattern.
- **`missingClusterResult` → `RUNNING`**: when the cluster is absent from Clouddriver's cache entirely, this is a transient condition during a service restart. Retry until the existing 30-min `OverridableTimeoutRetryableTask` timeout rather than going TERMINAL immediately.

## Root cause

During a Spinnaker self-deploy, the pipeline redeploys Spinnaker itself. Clouddriver restarts mid-execution with a cold cache. When `waitForClusterDisable` ran against the freshly-started Clouddriver, it got back either no cluster or a cluster with an empty server-group list. The base-class `emptyClusterResult`/`missingClusterResult` both throw `IllegalStateException`, which propagates out of `execute()` and bypasses the `OverridableTimeoutRetryableTask` retry loop entirely, going straight to TERMINAL after just ~109ms.

The force-cache-refresh task before it showed `processed.server.groups: []` and `refreshed.server.groups: []` — confirming Clouddriver's cache was cold at that point.

## Why `SUCCEEDED` for empty, not `RUNNING`

With a red/black + `scaleDown: true` deploy strategy, the createServerGroup stage already disables and scales down the old server group before the explicit `disableCluster` stage runs. An empty cluster means the old ASG is already gone — that's the success condition, not a failure. `WaitForClusterShrinkTask` makes the same call for the same reason.

## Test plan

- [x] Updated `WaitForClusterDisableTaskSpec` — replaced the `IllegalStateException` assertions with status assertions for both cases
- [x] Verified RED (both new tests failed with the base-class throw before the fix)
- [x] Verified GREEN (`./gradlew :orca:orca-clouddriver:test --tests "...WaitForClusterDisableTaskSpec"` passes clean)
- [ ] Observe next Spinnaker self-deploy completes without intermittent `waitForClusterDisable` TERMINAL failure