### PR TITLE
fix(azure): populate instance zone from the VMSS VM availability zone

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstance.groovy
@@ -33,7 +33,7 @@ class AzureInstance implements Instance, Serializable {
   String vhd
   HealthState healthState
   Long launchTime
-  final String zone = 'N/A'
+  String zone = 'N/A'
   String instanceType
   List<Map<String, Object>> health
   final String providerType = AzureCloudProvider.ID
@@ -45,6 +45,11 @@ class AzureInstance implements Instance, Serializable {
     instance.instanceType = vm.sku().name()
     instance.resourceId = vm.instanceId()
     instance.vhd = vm.storageProfile()?.osDisk()?.vhd()?.uri()
+
+    // A scale set VM lives in at most one availability zone; surface it so Deck can
+    // display zone placement the way it does for other providers. Regions without
+    // zone support (or VMs not pinned to a zone) report no zones, so keep 'N/A'.
+    instance.zone = vm.innerModel()?.zones()?.getAt(0) ?: 'N/A'
 
     vm.instanceView()?.statuses()?.each { status ->
       def codes = status.code()?.split('/')

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstanceSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/model/AzureInstanceSpec.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model
 
+import com.azure.resourcemanager.compute.fluent.models.VirtualMachineScaleSetVMInner
 import com.azure.resourcemanager.compute.models.InstanceViewStatus
 import com.azure.resourcemanager.compute.models.Sku
 import com.azure.resourcemanager.compute.models.VirtualMachineInstanceView
@@ -50,5 +51,31 @@ class AzureInstanceSpec extends Specification {
     expect:
       instance.zone == 'N/A'
       instance.healthState == HealthState.Up
+  }
+
+  def 'should populate zone from the VMSS VM availability zone, falling back to N/A'(){
+    def vm = Mock(VirtualMachineScaleSetVM)
+    def sku = new Sku()
+
+    vm.innerModel() >> innerWithZones(zones)
+    vm.sku() >> sku
+    sku.name() >> "test"
+
+    expect:
+      AzureInstance.build(vm).zone == expectedZone
+
+    where:
+      zones || expectedZone
+      ['1'] || '1'
+      null  || 'N/A'
+      []    || 'N/A'
+  }
+
+  private static VirtualMachineScaleSetVMInner innerWithZones(List<String> zones) {
+    def inner = new VirtualMachineScaleSetVMInner()
+    def field = VirtualMachineScaleSetVMInner.getDeclaredField('zones')
+    field.accessible = true
+    field.set(inner, zones)
+    inner
   }
 }


### PR DESCRIPTION
## Summary

Azure instances always displayed in zone `N/A` in Deck because `AzureInstance.zone` was hardcoded to `'N/A'` and never read from the VM. AWS surfaces the EC2 availability zone on each instance; Azure had the data on the scale set VM but discarded it in the instance builder.

This populates the zone from the VMSS VM's availability zone (`"1"`/`"2"`/`"3"`), falling back to `'N/A'` for regions without zone support or VMs not pinned to a zone.

## Changes

- `AzureInstance.groovy`: read the availability zone via `vm.innerModel()?.zones()?.getAt(0)` and assign it to `zone`. The high-level fluent `VirtualMachineScaleSetVM` interface does not expose zones, so the inner model is used (consistent with how `AzureServerGroupDescription` reads `scaleSet.zones()`). The `zone` field is no longer `final` so the builder can set it.
- `AzureInstanceSpec.groovy`: data-driven spec covering a zoned VM (`['1'] → '1'`) and the fallback cases (`null` / `[]` → `'N/A'`).

## Notes

This fixes zone on instances cached going forward; existing cached instances will continue to show `N/A` until the caching agent re-runs.

## Test plan

- [x] `:clouddriver:clouddriver-azure:test --tests "*AzureInstanceSpec*"` passes (4/4)