### PR TITLE
fix(clouddriver-azure): evict stale cache after server group destroy

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -17,8 +17,11 @@
 package com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops
 
 import com.netflix.frigga.Names
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
 import com.netflix.spinnaker.clouddriver.azure.common.AzureUtilities
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
+import com.netflix.spinnaker.clouddriver.cache.OnDemandType
 import com.netflix.spinnaker.clouddriver.data.task.Task
 import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
@@ -33,9 +36,12 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   }
 
   private final EnableDisableDestroyAzureServerGroupDescription description
+  private final List<OnDemandCacheUpdater> onDemandCacheUpdaters
 
-  DestroyAzureServerGroupAtomicOperation(EnableDisableDestroyAzureServerGroupDescription description) {
+  DestroyAzureServerGroupAtomicOperation(EnableDisableDestroyAzureServerGroupDescription description,
+                                         List<OnDemandCacheUpdater> onDemandCacheUpdaters = []) {
     this.description = description
+    this.onDemandCacheUpdaters = onDemandCacheUpdaters
   }
 
   /**
@@ -138,8 +144,16 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
 
     if (errList.isEmpty()) {
       task.updateStatus BASE_PHASE, "Destroy Azure Server Group Operation for ${description.name} succeeded."
-    }
-    else {
+      onDemandCacheUpdaters.each {
+        if (it.handles(OnDemandType.ServerGroup, AzureCloudProvider.ID)) {
+          it.handle(OnDemandType.ServerGroup, AzureCloudProvider.ID, [
+            serverGroupName: description.name,
+            account        : description.accountName,
+            region         : region
+          ])
+        }
+      }
+    } else {
       errList.add(" Go to Azure Portal for more info")
       throw new AtomicOperationException("Failed to destroy ${description.name}", errList)
     }

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/DestroyAzureServerGroupAtomicOperation.groovy
@@ -27,7 +27,9 @@ import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+import groovy.util.logging.Slf4j
 
+@Slf4j
 class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
   private static final String BASE_PHASE = "DESTROY_SERVER_GROUP"
 
@@ -146,11 +148,16 @@ class DestroyAzureServerGroupAtomicOperation implements AtomicOperation<Void> {
       task.updateStatus BASE_PHASE, "Destroy Azure Server Group Operation for ${description.name} succeeded."
       onDemandCacheUpdaters.each {
         if (it.handles(OnDemandType.ServerGroup, AzureCloudProvider.ID)) {
-          it.handle(OnDemandType.ServerGroup, AzureCloudProvider.ID, [
-            serverGroupName: description.name,
-            account        : description.accountName,
-            region         : region
-          ])
+          try {
+            it.handle(OnDemandType.ServerGroup, AzureCloudProvider.ID, [
+              serverGroupName: description.name,
+              account        : description.accountName,
+              region         : region
+            ])
+          } catch (Exception e) {
+            // best-effort: background sweep reconciles within ~60s regardless
+            log.warn("Failed to evict ${description.name} from on-demand cache after destroy: ${e.message}")
+          }
         }
       }
     } else {

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroup/ops/converters/DestroyAzureServerGroupAtomicOperationConverter.groovy
@@ -20,23 +20,28 @@ import com.netflix.spinnaker.clouddriver.azure.AzureOperation
 import com.netflix.spinnaker.clouddriver.azure.common.AzureAtomicOperationConverterHelper
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
 import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperation
 import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperations
 import com.netflix.spinnaker.clouddriver.security.AbstractAtomicOperationsCredentialsSupport
 import groovy.util.logging.Slf4j
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
 @Slf4j
 @AzureOperation(AtomicOperations.DESTROY_SERVER_GROUP)
 @Component("destroyAzureServerGroupDescription")
 class DestroyAzureServerGroupAtomicOperationConverter extends AbstractAtomicOperationsCredentialsSupport {
+  @Autowired(required = false)
+  List<OnDemandCacheUpdater> onDemandCacheUpdaters = []
+
   DestroyAzureServerGroupAtomicOperationConverter() {
     log.trace("Constructor....DestroyAzureServerGroupAtomicOperationConverter")
   }
 
   @Override
   AtomicOperation convertOperation(Map input) {
-    new DestroyAzureServerGroupAtomicOperation(convertDescription(input))
+    new DestroyAzureServerGroupAtomicOperation(convertDescription(input), onDemandCacheUpdaters)
   }
 
   @Override

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationUnitSpec.groovy
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2026 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.resources.servergroups.deploy.ops
+
+import com.netflix.spinnaker.clouddriver.azure.AzureCloudProvider
+import com.netflix.spinnaker.clouddriver.azure.client.AzureComputeClient
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.AzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.model.EnableDisableDestroyAzureServerGroupDescription
+import com.netflix.spinnaker.clouddriver.azure.resources.servergroup.ops.DestroyAzureServerGroupAtomicOperation
+import com.netflix.spinnaker.clouddriver.azure.security.AzureCredentials
+import com.netflix.spinnaker.clouddriver.cache.OnDemandCacheUpdater
+import com.netflix.spinnaker.clouddriver.cache.OnDemandType
+import com.netflix.spinnaker.clouddriver.data.task.Task
+import com.netflix.spinnaker.clouddriver.data.task.TaskRepository
+import com.netflix.spinnaker.clouddriver.orchestration.AtomicOperationException
+import spock.lang.Specification
+import spock.lang.Subject
+
+class DestroyAzureServerGroupAtomicOperationUnitSpec extends Specification {
+
+  static final SERVER_GROUP_NAME = "testazure-web1-d1-v000"
+  static final ACCOUNT_NAME = "my-azure-account"
+  static final REGION = "westus"
+  static final APP_NAME = "testazure"
+  static final RESOURCE_GROUP = "${APP_NAME}-${REGION}"
+
+  AzureComputeClient computeClient
+  AzureCredentials credentials
+  EnableDisableDestroyAzureServerGroupDescription description
+  OnDemandCacheUpdater onDemandCacheUpdater
+
+  def setup() {
+    TaskRepository.threadLocalTask.set(Mock(Task))
+
+    computeClient = GroovyMock(AzureComputeClient)
+    credentials = GroovyMock(AzureCredentials) {
+      asBoolean() >> true
+      getComputeClient() >> computeClient
+    }
+
+    description = new EnableDisableDestroyAzureServerGroupDescription(
+      name: SERVER_GROUP_NAME,
+      serverGroupName: SERVER_GROUP_NAME,
+      accountName: ACCOUNT_NAME,
+      region: REGION,
+      application: APP_NAME,
+      credentials: credentials
+    )
+
+    onDemandCacheUpdater = Mock(OnDemandCacheUpdater) {
+      handles(OnDemandType.ServerGroup, AzureCloudProvider.ID) >> true
+    }
+  }
+
+  void "triggers on-demand cache eviction for destroyed server group"() {
+    given:
+    def serverGroupDescription = new AzureServerGroupDescription(storageAccountNames: [], enableInboundNAT: false, hasNewSubnet: false)
+    computeClient.getServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> serverGroupDescription
+
+    @Subject
+    def operation = new DestroyAzureServerGroupAtomicOperation(description, [onDemandCacheUpdater])
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * computeClient.destroyServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME)
+    1 * onDemandCacheUpdater.handle(OnDemandType.ServerGroup, AzureCloudProvider.ID, [
+      serverGroupName: SERVER_GROUP_NAME,
+      account        : ACCOUNT_NAME,
+      region         : REGION
+    ])
+  }
+
+  void "does not trigger on-demand cache eviction when destroy fails"() {
+    given:
+    def serverGroupDescription = new AzureServerGroupDescription(storageAccountNames: [], enableInboundNAT: false, hasNewSubnet: false)
+    computeClient.getServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> serverGroupDescription
+    computeClient.destroyServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> { throw new RuntimeException("Azure API error") }
+
+    @Subject
+    def operation = new DestroyAzureServerGroupAtomicOperation(description, [onDemandCacheUpdater])
+
+    when:
+    operation.operate([])
+
+    then:
+    thrown(AtomicOperationException)
+    0 * onDemandCacheUpdater.handle(_, _, _)
+  }
+
+  void "works correctly when no on-demand cache updaters are registered"() {
+    given:
+    def serverGroupDescription = new AzureServerGroupDescription(storageAccountNames: [], enableInboundNAT: false, hasNewSubnet: false)
+    computeClient.getServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> serverGroupDescription
+
+    @Subject
+    def operation = new DestroyAzureServerGroupAtomicOperation(description)
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * computeClient.destroyServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME)
+    noExceptionThrown()
+  }
+
+  void "does not call updaters that do not handle azure server groups"() {
+    given:
+    def serverGroupDescription = new AzureServerGroupDescription(storageAccountNames: [], enableInboundNAT: false, hasNewSubnet: false)
+    computeClient.getServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> serverGroupDescription
+
+    def nonAzureUpdater = Mock(OnDemandCacheUpdater) {
+      handles(OnDemandType.ServerGroup, AzureCloudProvider.ID) >> false
+    }
+
+    @Subject
+    def operation = new DestroyAzureServerGroupAtomicOperation(description, [nonAzureUpdater, onDemandCacheUpdater])
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * computeClient.destroyServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME)
+    0 * nonAzureUpdater.handle(_, _, _)
+    1 * onDemandCacheUpdater.handle(OnDemandType.ServerGroup, AzureCloudProvider.ID, [
+      serverGroupName: SERVER_GROUP_NAME,
+      account        : ACCOUNT_NAME,
+      region         : REGION
+    ])
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationUnitSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/resources/servergroups/deploy/ops/DestroyAzureServerGroupAtomicOperationUnitSpec.groovy
@@ -143,4 +143,21 @@ class DestroyAzureServerGroupAtomicOperationUnitSpec extends Specification {
       region         : REGION
     ])
   }
+
+  void "destroy succeeds even when on-demand cache eviction throws"() {
+    given:
+    def serverGroupDescription = new AzureServerGroupDescription(storageAccountNames: [], enableInboundNAT: false, hasNewSubnet: false)
+    computeClient.getServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME) >> serverGroupDescription
+    onDemandCacheUpdater.handle(_, _, _) >> { throw new RuntimeException("Azure 429 throttled") }
+
+    @Subject
+    def operation = new DestroyAzureServerGroupAtomicOperation(description, [onDemandCacheUpdater])
+
+    when:
+    operation.operate([])
+
+    then:
+    1 * computeClient.destroyServerGroup(RESOURCE_GROUP, SERVER_GROUP_NAME)
+    noExceptionThrown()
+  }
 }


### PR DESCRIPTION
## Summary

- `DestroyAzureServerGroupAtomicOperation` now triggers an on-demand cache update via `OnDemandCacheUpdater` after a successful Azure VMSS deletion
- The converter autowires `List<OnDemandCacheUpdater>` (optional) and passes it to the operation via constructor injection
- 4 new unit tests cover: successful eviction, no eviction on failure, empty updater list, and filtering non-azure updaters

## Root cause

Diagnosed from live orca + clouddriver logs on `10.0.1.191` during pipeline `01KT1TXBBZ89DNQ960Z02S9YVQ` (`deploy-devaz`, app `monitoringatlas2`):

1. `v029` deployed and healthy at 14:57
2. `DestroyAzureServerGroupAtomicOperation` ran at 15:12–15:14 and **successfully deleted** `v025` and `v026` from Azure
3. Clouddriver's caching agents immediately started getting 404s from Azure for those VMSSes — confirming deletion
4. **But**: no on-demand cache invalidation was triggered, so the entries stayed in clouddriver's cache
5. `WaitForClusterShrinkTask` polls clouddriver's cache (not Azure directly), saw them still present for 10+ minutes, and timed out at 15:25 after 30 minutes

## Why the fix works

`AzureServerGroupCachingAgent.handle()` already implements the full eviction path: it fetches the server group directly (gets 404), writes an eviction tombstone to `AZURE_EVICTIONS`, and returns the key as an eviction — which the cats framework applies to the primary cache immediately. We just needed to call it after the delete succeeds.

## Before

```mermaid
sequenceDiagram
    participant Orca
    participant Clouddriver
    participant Azure
    participant Cache as Clouddriver Cache
    participant Task as WaitForClusterShrinkTask

    Orca->>Clouddriver: destroyServerGroup(v025, v026)
    Clouddriver->>Azure: DELETE VMSS v025, v026
    Azure-->>Clouddriver: ✅ deleted
    Clouddriver-->>Orca: ✅ done
    Note over Cache: v025, v026 still in cache
    loop every 30s for 30 min
        Task->>Cache: are v025/v026 gone?
        Cache-->>Task: ❌ still present (stale)
    end
    Task-->>Orca: ❌ TIMEOUT — shrinkCluster TERMINAL
```

## After

```mermaid
sequenceDiagram
    participant Orca
    participant Clouddriver
    participant Azure
    participant Cache as Clouddriver Cache
    participant Task as WaitForClusterShrinkTask

    Orca->>Clouddriver: destroyServerGroup(v025, v026)
    Clouddriver->>Azure: DELETE VMSS v025, v026
    Azure-->>Clouddriver: ✅ deleted
    Clouddriver->>Azure: getServerGroup(v025) — on-demand eviction
    Azure-->>Clouddriver: 404 Not Found
    Clouddriver->>Cache: evict v025, write tombstone
    Clouddriver->>Azure: getServerGroup(v026) — on-demand eviction
    Azure-->>Clouddriver: 404 Not Found
    Clouddriver->>Cache: evict v026, write tombstone
    Clouddriver-->>Orca: ✅ done
    Task->>Cache: are v025/v026 gone?
    Cache-->>Task: ✅ gone
    Task-->>Orca: ✅ shrinkCluster SUCCEEDED
```

## Red-team validation (unpatched instance `10.0.1.162`)

A full Azure tenant repave was run against the unpatched instance to gather a large empirical sample. **40 Azure server group destroys** were observed across multiple apps (`monitoringatlas2`, `codesearch2`, `changesetreader2`, `auditreader2`, `authz2`, `authn2`, `gateway2`, `moddy2`, `connector2`, `recipeworker2`, `recipemarketplace2`, `changelogwriter2`, `changelogreader2`, `changesetcommitter2`, `changesetbatch2`, `changesetvisualizer2`, `organization2`, `artifactsmaven2`, `artifactsindexwriter2`, `moderneui2`).

**Every single destroy showed the same stale-cache pattern — 0 exceptions.**

### Evidence chain (confirmed for all 40 destroys)

1. **Destroy succeeds** — clouddriver logs `Done destroying Azure server group X` and `Destroy Azure Server Group Operation for X succeeded`
2. **Azure confirms deletion** — caching agents begin receiving `404 ResourceNotFound` for the deleted VMSS immediately after
3. **No on-demand eviction fires** — zero `onDemand cache refresh` log entries for destroyed server groups; contrast with AWS which logs `evictions: [serverGroups:[aws:serverGroups:...]]` on every on-demand refresh
4. **Cache eviction only via background poll** — entries are only removed when `AzureServerGroupCachingAgent`'s scheduled polling cycle runs and calls `removeDeadCacheEntries()`

### Stale cache gap across 40 destroys

| Time | Server groups destroyed | Cache evicted | Stale gap |
|---|---|---|---|
| 15:48:27 | 1 (v027) | 15:49:23 | 56s |
| 16:58:35–49 | 3 (v028, codesearch-v009, changesetreader-v025) | 16:59:29 | 40–54s |
| 16:59:41–49 | 10 (authz, auditreader, changesetcommitter, changelogwriter, organization, artifactsmaven, gateway, changesetvisualizer, changesetbatch, artifactsindexwriter) | 17:00:30 | 41–49s |
| 17:00:43–48 | 3 (changelogreader-v010, moddy-v009, recipeworker-v022) | 17:01:28 | 40–45s |
| 17:01:43–44 | 2 (authn-v012, recipemarketplace-v024) | 17:02:37 | 53–54s |
| 17:02:56 | 1 (connector-v018) | 17:03:32 | 36s |
| 17:46:45–47:07 | **19** (full repave wave — all apps) | 17:48:08 | 61–83s |
| 17:49:10 | 1 (connector-v019) | 17:50:00 | 50s |

**Gap: min 36s · max 83s · average ~58s**

The wave-7 batch is the most telling: 19 server groups destroyed in a 22-second burst all remain stale until a single background poll evicts all 19 at once 61–83 seconds later. Under the Azure throttling and `freshDataLooksComplete` suspicion guard seen in the original failure, this gap can easily widen past 30 minutes.

### AWS contrast

AWS destroy operations trigger an on-demand cache refresh immediately via `ClusterCachingAgent`, which logs non-empty evictions inline:
```
onDemand cache refresh (evictions: [serverGroups:[aws:serverGroups:changelogwriter2-dev:moderne-aws:us-west-2:changelogwriter2-dev-v013]])
```
Azure on-demand refreshes consistently log `evictions: [:]` — the eviction path is never taken on demand, only in the background sweep.

## Test plan

- [x] `DestroyAzureServerGroupAtomicOperationUnitSpec` — 4 new tests, all green
- [x] Full `clouddriver-azure` test suite — pre-existing failures unchanged (25 unrelated template/gateway tests were already failing before this change)