### PR TITLE
fix(orca+clouddriver): prevent server group sequence cycling and stale-tag disable errors

### DIFF
--- a/clouddriver/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolver.groovy
+++ b/clouddriver/clouddriver-core/src/main/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolver.groovy
@@ -52,9 +52,24 @@ abstract class AbstractServerGroupNameResolver extends NameBuilder {
   String resolveLatestServerGroupName(String clusterName, List<TakenSlot> takenSlots = []) {
     takenSlots = takenSlots ?: getTakenSlots(clusterName)
 
-    // Attempt to find the server group created most recently.
+    // Find the server group with the highest Frigga sequence number.
+    //
+    // Previously this sorted by TakenSlot.createdTime, but all slots populated
+    // from a single getServerGroupsAll() call share the same lastReadTime value
+    // (set once at the top of that method). Every comparison ties, so Groovy's
+    // max() returns whichever slot happens to be first in the Azure/AWS API
+    // response — typically the alphabetically-lowest name — rather than the
+    // most recently deployed one. This causes resolveNextServerGroupName to
+    // anchor on an old low-sequence shell and reuse deleted sequence slots,
+    // producing new server groups with sequence numbers lower than existing
+    // ones. That breaks the invariant relied on by DisableClusterTask and
+    // ScaleDownClusterTask when ordering server groups.
+    //
+    // Sequence numbers are assigned by Spinnaker at naming time and are always
+    // strictly monotonically increasing within a cluster, so max(sequence) is
+    // the correct anchor regardless of creation timestamps.
     def latestServerGroup = takenSlots?.max { a, b ->
-      a.createdTime <=> b.createdTime
+      (a.sequence ?: 0) <=> (b.sequence ?: 0)
     }
 
     return latestServerGroup ? latestServerGroup.serverGroupName : null

--- a/clouddriver/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
+++ b/clouddriver/clouddriver-core/src/test/groovy/com/netflix/spinnaker/clouddriver/helpers/AbstractServerGroupNameResolverSpec.groovy
@@ -126,7 +126,12 @@ class AbstractServerGroupNameResolverSpec extends Specification {
     999      || false
   }
 
-  void "resolveNextServerGroupName should yield v001 when most recent server group does not define sequence number"() {
+  void "resolveNextServerGroupName anchors on the highest-sequence slot even when a no-sequence slot exists"() {
+    // A non-versioned server group (e.g. app-dev, no vNNN suffix) has sequence=null.
+    // The resolver must still anchor on the highest real sequence so the next
+    // deploy gets a strictly increasing name rather than resetting to v001.
+    // Deploying v001 alongside an existing v997 would be confusing and could
+    // interfere with cluster-wide ordering in DisableCluster/ScaleDownCluster.
     setup:
     def takenSlots = [
       buildTakenSlot('app-dev-v997', 997),
@@ -138,7 +143,48 @@ class AbstractServerGroupNameResolverSpec extends Specification {
     def nextServerGroupName = serverGroupNameResolver.resolveNextServerGroupName('app', 'dev', null, false)
 
     then:
+    nextServerGroupName == 'app-dev-v998'
+  }
+
+  void "resolveNextServerGroupName should yield v001 when all slots have no sequence number"() {
+    setup:
+    def takenSlots = [
+      buildTakenSlot('app-dev', 998),
+    ]
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
+
+    when:
+    def nextServerGroupName = serverGroupNameResolver.resolveNextServerGroupName('app', 'dev', null, false)
+
+    then:
     nextServerGroupName == 'app-dev-v001'
+  }
+
+  void "resolveNextServerGroupName anchors on max sequence when all slots share the same lastReadTime"() {
+    // Regression: AzureComputeClient.getServerGroupsAll() stamps every slot with
+    // the same lastReadTime (captured once before the loop). When all TakenSlot
+    // createdTimes tie, Groovy's max() used to return the first element in
+    // iteration order — typically the alphabetically-lowest name — instead of
+    // the most recently deployed one. This caused the resolver to anchor on an
+    // old low-sequence shell (e.g. v031) and reuse deleted slots, producing new
+    // server groups with sequence numbers lower than existing ones (e.g. creating
+    // v034 when v035 already exists). The fix uses sequence number to find the
+    // true latest, guaranteeing strictly-increasing sequences.
+    setup:
+    def sharedLastReadTime = 1_000_000L  // all slots identical, as in a real batch fetch
+    def takenSlots = [
+      new TakenSlot(serverGroupName: 'app-stack-v031', sequence: 31, createdTime: new Date(sharedLastReadTime)),
+      new TakenSlot(serverGroupName: 'app-stack-v032', sequence: 32, createdTime: new Date(sharedLastReadTime)),
+      new TakenSlot(serverGroupName: 'app-stack-v033', sequence: 33, createdTime: new Date(sharedLastReadTime)),
+      new TakenSlot(serverGroupName: 'app-stack-v035', sequence: 35, createdTime: new Date(sharedLastReadTime)),
+    ]
+    def serverGroupNameResolver = new TestServerGroupNameResolver(takenSlots)
+
+    when:
+    def nextServerGroupName = serverGroupNameResolver.resolveNextServerGroupName('app', 'stack', null, false)
+
+    then: 'anchors on v035 (max sequence), skips the free v034 slot, and returns v036'
+    nextServerGroupName == 'app-stack-v036'
   }
 
   private buildTakenSlot(String serverGroupName, long createdTime = 0) {

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/AbstractClusterWideClouddriverTask.groovy
@@ -16,6 +16,7 @@
 
 package com.netflix.spinnaker.orca.clouddriver.tasks.cluster
 
+import com.netflix.frigga.Names
 import com.netflix.spinnaker.orca.api.pipeline.Task
 import com.netflix.spinnaker.orca.api.pipeline.models.ExecutionStatus
 import com.netflix.spinnaker.orca.api.pipeline.RetryableTask
@@ -284,6 +285,20 @@ abstract class AbstractClusterWideClouddriverTask implements RetryableTask, Clou
     @Override
     int compare(TargetServerGroup o1, TargetServerGroup o2) {
       o2.createdTime <=> o1.createdTime
+    }
+  }
+
+  // Sorts by Frigga sequence number descending (higher sequence = newer deployment).
+  // Preferred over CreatedTime for ordering because createdTime is read from a
+  // provider-specific tag (e.g. the Azure VMSS `createdTime` tag) that can be stale
+  // when a disabled server group shell is reused by a later deploy — causing
+  // DisableCluster/ScaleDownCluster to treat the newly-deployed group as older and
+  // disable it instead of the previous one. Sequence is derived from the server
+  // group name itself and is always monotonically increasing.
+  static class Sequence implements Comparator<TargetServerGroup> {
+    @Override
+    int compare(TargetServerGroup o1, TargetServerGroup o2) {
+      (Names.parseName(o2.name).sequence ?: 0) <=> (Names.parseName(o1.name).sequence ?: 0)
     }
   }
 

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DisableClusterTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/DisableClusterTask.groovy
@@ -57,7 +57,7 @@ class DisableClusterTask extends AbstractClusterWideClouddriverTask {
 
     Comparator<TargetServerGroup> comparator = disableClusterConfig.preferLargerOverNewer ?
       new InstanceCount() :
-      new CreatedTime()
+      new Sequence()
 
     return filtered.sort(true, comparator).drop(dropCount)
   }

--- a/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTask.groovy
+++ b/orca/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTask.groovy
@@ -82,7 +82,7 @@ class ScaleDownClusterTask extends AbstractClusterWideClouddriverTask {
     if (config.preferLargerOverNewer) {
       comparators << new InstanceCount()
     }
-    comparators << new CreatedTime()
+    comparators << new Sequence()
 
     //result will be sorted in priority order to retain
     def prioritized = filteredGroups.sort(false, new CompositeComparator(comparators))

--- a/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTaskSpec.groovy
+++ b/orca/orca-clouddriver/src/test/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/cluster/ScaleDownClusterTaskSpec.groovy
@@ -68,6 +68,41 @@ class ScaleDownClusterTaskSpec extends Specification {
     expected = expectedIdx.collect { serverGroups[it] }
   }
 
+  def 'uses sequence number, not createdTime, to identify the newest server group'() {
+    // Regression test: when a disabled VMSS shell is reused by a new deploy the
+    // createdTime tag on the resource can be stale (from the original creation),
+    // making the new server group appear older than the previous one.  Ordering
+    // must be driven by sequence number (derived from the name) which is always
+    // monotonically increasing and cannot be stale.
+    given:
+    def location = new Location(Location.Type.REGION, 'us-east-1')
+    // v035 is the *newly deployed* group but has an older createdTime because
+    // its VMSS shell was created during a previous (failed) pipeline run.
+    def newGroup = new TargetServerGroup(
+      name: 'app-stack-v035', region: 'us-east-1',
+      createdTime: 1000L,   // stale — yesterday's timestamp
+      disabled: true,
+      instances: [[id: 'i1', healthState: 'Up']]
+    )
+    // v034 is the previous group and has a more recent createdTime (set today).
+    def oldGroup = new TargetServerGroup(
+      name: 'app-stack-v034', region: 'us-east-1',
+      createdTime: 9999L,   // newer timestamp, but lower sequence
+      disabled: true,
+      instances: [[id: 'i2', healthState: 'Up']]
+    )
+    def stage = new StageExecutionImpl(
+      PipelineExecutionImpl.newPipeline("orca"), "scaleDownCluster",
+      [remainingFullSizeServerGroups: 1, allowScaleDownActive: true]
+    )
+
+    when:
+    def result = task.filterServerGroups(stage, 'test', location, [newGroup, oldGroup])
+
+    then: 'the lower-sequence (older) group is selected for scale-down, not the higher-sequence new one'
+    result == [oldGroup]
+  }
+
   static final AtomicInteger inc = new AtomicInteger()
 
   TargetServerGroup sg(boolean disabled = false, int instances = 10) {


### PR DESCRIPTION
## Summary

Two co-dependent fixes for a class of bug that causes the wrong server group to be disabled after a deploy.

### Root cause (traced empirically across 10 executions)

`AbstractServerGroupNameResolver.resolveLatestServerGroupName()` finds the anchor server group by sorting `TakenSlot.createdTime`. All slots from a single `getServerGroupsAll()` call share the **same** `lastReadTime` (captured once before the loop), so every comparison ties. Groovy's `max()` then returns the **first element in iteration order** — the alphabetically-lowest name in the cluster (e.g. `v031`). The resolver anchors there, increments from that low sequence, and picks up whatever deleted slot is next free — producing new server groups with **sequence numbers lower than existing ones**.

Traced over 10 consecutive `deploy-morganstanley` runs:

| Date | Anchor | Created | Why not anchor+1? |
|------|--------|---------|-------------------|
| Jun 11 | v029 | v032 | v031 deleted, slot free |
| Jun 12 | v030 | v033 | v031 deleted again |
| Jun 13 | v030 | v031 | v031 deleted Jun 12 |
| Jun 14 | v031 | v034 | v034 slot free |
| Jun 15 | v031 | v032 | v032 deleted Jun 14 |
| Jun 16 4pm | v031 | v033 | v033 deleted Jun 15 |
| Jun 16 4:30pm | v031 | v035 | v033/v034 taken → v035 |
| Jun 17 | v032 | v034 | v034 deleted Jun 16 |

Today's incident: resolver created `v034` (seq=34) while `v035` (seq=35, Jun 16) already existed. `DisableClusterTask` used `createdTime` to pick the "newest" — correctly kept `v034` (today) and disabled `v035` (Jun 16). But if the `createdTime` tag on the new server group had been stale (a separate known failure mode when a disabled VMSS shell is reused), `v035` would have appeared newer and the wrong group would have been disabled.

### Fix 1 — clouddriver: anchor on max sequence, not createdTime

**`clouddriver-core/…/AbstractServerGroupNameResolver.groovy`**

Change `resolveLatestServerGroupName` to sort by `TakenSlot.sequence` instead of `TakenSlot.createdTime`. Sequence numbers are assigned by Spinnaker at naming time and are always strictly monotonically increasing within a cluster — immune to timestamp ties or API ordering.

With this fix the resolver always anchors on `v035` (seq=35, the true latest) and returns `v036`, ensuring all new deployments get strictly-increasing sequences.

### Fix 2 — orca: order cluster tasks by sequence number, not createdTime

**`orca-clouddriver/…/DisableClusterTask.groovy`** and **`ScaleDownClusterTask.groovy`**

Replace the `CreatedTime` comparator with a new `Sequence` comparator in `AbstractClusterWideClouddriverTask`. For Azure, `createdTime` is read from a VMSS **tag** set at initial resource creation — it can be stale when a disabled VMSS shell is reused by a later deploy, causing `DisableClusterTask` to keep the old server group and disable the newly-deployed one.

For AWS, `createdTime` comes from the AWS API and is reliable, so this change is a safe no-op in practice.

This fix is **only safe once Fix 1 is in place**: with strictly-increasing sequences guaranteed, `Sequence` and `createdTime` will always agree, and the Sequence comparator is correct and stale-tag-immune.

## Test plan

- [x] `AbstractServerGroupNameResolverSpec` — 21 tests pass including new regression test covering the same-`lastReadTime` incident scenario and the updated null-sequence behavior
- [x] `ScaleDownClusterTaskSpec` — 9 tests pass including new regression test for stale-`createdTime` scenario (v035 with older timestamp must not be scaled down over v034 with newer timestamp when v035 has higher sequence)