### PR TITLE
fix(deck): prevent AppRefresherIcon scheduler/listener leak on re-render

### DIFF
--- a/deck/packages/core/src/application/nav/AppRefresherIcon.spec.tsx
+++ b/deck/packages/core/src/application/nav/AppRefresherIcon.spec.tsx
@@ -1,36 +1,54 @@
 import { mock } from 'angular';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import React from 'react';
 
 import { AppRefresherIcon } from './AppRefresherIcon';
 import { REACT_MODULE } from '../../reactShims';
+import type { IScheduler } from '../../scheduler';
 import { SchedulerFactory } from '../../scheduler';
 
 describe('<AppRefresherIcon/>', () => {
   beforeEach(mock.module(REACT_MODULE));
   beforeEach(mock.inject(() => {})); // Angular is lazy.
 
-  it('does not create a new scheduler when re-rendering without a lastRefresh change', () => {
-    const fakeScheduler = {
+  function makeFakeScheduler(): IScheduler {
+    return {
       subscribe: jasmine.createSpy('subscribe'),
       scheduleImmediate: jasmine.createSpy('scheduleImmediate'),
       unsubscribe: jasmine.createSpy('unsubscribe'),
-    };
-    const createScheduler = spyOn(SchedulerFactory, 'createScheduler').and.returnValue(fakeScheduler as any);
+    } as any;
+  }
 
-    const wrapper = shallow(
+  it('creates a single scheduler and does not create another on a lastRefresh-stable re-render', () => {
+    const createScheduler = spyOn(SchedulerFactory, 'createScheduler').and.returnValue(makeFakeScheduler());
+
+    const wrapper = mount(
       <AppRefresherIcon appName="myapp" lastRefresh={1000} refreshing={false} refresh={() => undefined} />,
     );
 
-    // Ignore any scheduler created during the initial render; we only care about re-renders.
-    createScheduler.calls.reset();
+    // The scheduler (an rxjs timer plus visibilitychange/online/offline listeners) is created by the
+    // effect, not in the render body, so exactly one exists after mount.
+    expect(createScheduler).toHaveBeenCalledTimes(1);
 
-    // A re-render that does NOT change lastRefresh (e.g. the refresh state toggling on click,
-    // a `refreshing` prop change, or a parent re-render) must not spin up another scheduler.
-    // Each scheduler registers an rxjs timer plus visibilitychange/online/offline listeners that
-    // are only torn down via unsubscribe(), so creating one per render leaks them for the session.
+    // A re-render that does NOT change lastRefresh (the refresh state toggling on click, a
+    // `refreshing` prop change, or a parent re-render) must not spin up another scheduler, otherwise
+    // its timer and listeners leak for the rest of the session.
     wrapper.setProps({ refreshing: true });
+    expect(createScheduler).toHaveBeenCalledTimes(1);
 
-    expect(createScheduler).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+
+  it('tears down the scheduler on unmount', () => {
+    const fakeScheduler = makeFakeScheduler();
+    spyOn(SchedulerFactory, 'createScheduler').and.returnValue(fakeScheduler);
+
+    const wrapper = mount(
+      <AppRefresherIcon appName="myapp" lastRefresh={1000} refreshing={false} refresh={() => undefined} />,
+    );
+    expect(fakeScheduler.unsubscribe).not.toHaveBeenCalled();
+
+    wrapper.unmount();
+    expect(fakeScheduler.unsubscribe).toHaveBeenCalledTimes(1);
   });
 });

--- a/deck/packages/core/src/application/nav/AppRefresherIcon.spec.tsx
+++ b/deck/packages/core/src/application/nav/AppRefresherIcon.spec.tsx
@@ -1,0 +1,36 @@
+import { mock } from 'angular';
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import { AppRefresherIcon } from './AppRefresherIcon';
+import { REACT_MODULE } from '../../reactShims';
+import { SchedulerFactory } from '../../scheduler';
+
+describe('<AppRefresherIcon/>', () => {
+  beforeEach(mock.module(REACT_MODULE));
+  beforeEach(mock.inject(() => {})); // Angular is lazy.
+
+  it('does not create a new scheduler when re-rendering without a lastRefresh change', () => {
+    const fakeScheduler = {
+      subscribe: jasmine.createSpy('subscribe'),
+      scheduleImmediate: jasmine.createSpy('scheduleImmediate'),
+      unsubscribe: jasmine.createSpy('unsubscribe'),
+    };
+    const createScheduler = spyOn(SchedulerFactory, 'createScheduler').and.returnValue(fakeScheduler as any);
+
+    const wrapper = shallow(
+      <AppRefresherIcon appName="myapp" lastRefresh={1000} refreshing={false} refresh={() => undefined} />,
+    );
+
+    // Ignore any scheduler created during the initial render; we only care about re-renders.
+    createScheduler.calls.reset();
+
+    // A re-render that does NOT change lastRefresh (e.g. the refresh state toggling on click,
+    // a `refreshing` prop change, or a parent re-render) must not spin up another scheduler.
+    // Each scheduler registers an rxjs timer plus visibilitychange/online/offline listeners that
+    // are only torn down via unsubscribe(), so creating one per render leaks them for the session.
+    wrapper.setProps({ refreshing: true });
+
+    expect(createScheduler).not.toHaveBeenCalled();
+  });
+});

--- a/deck/packages/core/src/application/nav/AppRefresherIcon.tsx
+++ b/deck/packages/core/src/application/nav/AppRefresherIcon.tsx
@@ -16,11 +16,14 @@ export interface IAppRefreshIconProps {
 }
 
 export const AppRefresherIcon = ({ appName, lastRefresh, refresh, refreshing }: IAppRefreshIconProps) => {
-  const activeRefresher = SchedulerFactory.createScheduler(2000);
   const [timeSinceRefresh, setTimeSinceRefresh] = React.useState(relativeTime(lastRefresh));
   const [iconPulsing, setIconPulsing] = React.useState(false);
 
   React.useEffect(() => {
+    // Create the scheduler inside the effect so exactly one exists per mount/lastRefresh and is
+    // torn down on cleanup. Creating it in the render body leaked a timer plus
+    // visibilitychange/online/offline listeners on every re-render that did not change lastRefresh.
+    const activeRefresher = SchedulerFactory.createScheduler(2000);
     activeRefresher.subscribe(() => {
       setTimeSinceRefresh(relativeTime(lastRefresh));
     });


### PR DESCRIPTION
## Problem

`AppRefresherIcon` is mounted persistently in the application header. It called
`SchedulerFactory.createScheduler(2000)` **in the render body**, while the
`useEffect` that subscribes to and tears down that scheduler is keyed on
`[lastRefresh]`.

Each call to `createScheduler` eagerly starts an RxJS `timer` and registers
`document` `visibilitychange` plus `window` `online`/`offline` listeners, which
are only removed via `unsubscribe()`. Because the scheduler was created on every
render but the effect only re-ran (and cleaned up) when `lastRefresh` changed,
any re-render that did **not** change `lastRefresh` — clicking refresh (toggles
`iconPulsing`), a `refreshing` prop change, or a parent re-render — created a
fresh, fully-wired scheduler that was never subscribed and never torn down. Its
timer and three global listeners leaked for the rest of the session.

## Fix

Move `createScheduler` inside the `useEffect` so exactly one scheduler exists per
mount/`lastRefresh` value and is disposed in the effect cleanup. Behavior is
otherwise unchanged (the relative-time tooltip still updates on the same 2s
cadence and re-evaluates when `lastRefresh` changes).

## Test

Adds `AppRefresherIcon.spec.tsx` asserting that a `lastRefresh`-stable re-render
(changing the `refreshing` prop) creates **no** additional scheduler. The test
fails on the old code and passes with the fix.

## Verification

- Full Deck Karma suite: **1749 passed, 0 failed** (the new spec fails before the
  fix, passes after).
- `eslint` clean on the changed source; `prettier --check` clean.
