### PR TITLE
fix(clouddriver-azure): retry VMSS resize on Azure 409 concurrent write conflicts

### DIFF
--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClient.groovy
@@ -164,7 +164,8 @@ abstract class AzureBaseClient {
     boolean retry = false
     if (e instanceof ManagementException) {
       def code = (e as ManagementException).getResponse().getStatusCode()
-      retry = (code == HttpURLConnection.HTTP_CLIENT_TIMEOUT
+      retry = (code == HttpURLConnection.HTTP_CONFLICT
+        || code == HttpURLConnection.HTTP_CLIENT_TIMEOUT
         || (code >= HttpURLConnection.HTTP_INTERNAL_ERROR && code <= HttpURLConnection.HTTP_GATEWAY_TIMEOUT))
     } else if (e instanceof SocketTimeoutException) {
       //If we get a socket time out try again

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -354,12 +354,12 @@ public class AzureComputeClient extends AzureBaseClient {
 
   Response<Void> resizeServerGroup(String resourceGroupName, String serverGroupName, int capacity) {
     try {
-      def vmss = executeOp({
-        azure.virtualMachineScaleSets().getByResourceGroup(resourceGroupName, serverGroupName)
+      executeOp({
+        def vmss = azure.virtualMachineScaleSets().getByResourceGroup(resourceGroupName, serverGroupName)
+        if (vmss != null) {
+          vmss.update().withCapacity(capacity).apply()
+        }
       })
-      if (vmss != null) {
-        executeOp({ vmss.update().withCapacity(capacity).apply() })
-      }
     } catch (ManagementException e) {
       if (resourceNotFound(e)) {
         log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")

--- a/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
+++ b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClient.groovy
@@ -357,7 +357,9 @@ public class AzureComputeClient extends AzureBaseClient {
       def vmss = executeOp({
         azure.virtualMachineScaleSets().getByResourceGroup(resourceGroupName, serverGroupName)
       })
-      vmss.update().withCapacity(capacity).apply()
+      if (vmss != null) {
+        executeOp({ vmss.update().withCapacity(capacity).apply() })
+      }
     } catch (ManagementException e) {
       if (resourceNotFound(e)) {
         log.warn("ServerGroup: ${e.message} (${serverGroupName} was not found)")

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClientSpec.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2026 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.client
+
+import com.azure.core.http.HttpResponse
+import com.azure.core.management.exception.ManagementException
+import org.mockito.Mockito
+import spock.lang.Specification
+import spock.lang.Unroll
+
+/**
+ * Tests for AzureBaseClient.executeOp retry logic, specifically that 409
+ * ConflictingConcurrentWriteNotAllowed is treated as a transient error and retried.
+ *
+ * executeOp is a static method so no instance allocation is needed.
+ */
+class AzureBaseClientSpec extends Specification {
+
+  private static ManagementException managementExceptionWithStatus(int statusCode) {
+    def httpResponse = Mockito.mock(HttpResponse)
+    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
+    new ManagementException("Simulated ${statusCode}", httpResponse)
+  }
+
+  @Unroll
+  def 'executeOp retries and succeeds after a transient #label'() {
+    given:
+    int callCount = 0
+    def ex = managementExceptionWithStatus(statusCode)
+
+    when:
+    def result = AzureBaseClient.executeOp({
+      if (++callCount == 1) throw ex
+      return "success"
+    }, 2L)
+
+    then:
+    result == "success"
+    callCount == 2
+
+    where:
+    statusCode                              | label
+    HttpURLConnection.HTTP_CONFLICT         | "409 Conflict (concurrent write)"
+    HttpURLConnection.HTTP_CLIENT_TIMEOUT   | "408 Request Timeout"
+    HttpURLConnection.HTTP_INTERNAL_ERROR   | "500 Internal Server Error"
+    HttpURLConnection.HTTP_UNAVAILABLE      | "503 Service Unavailable"
+    HttpURLConnection.HTTP_GATEWAY_TIMEOUT  | "504 Gateway Timeout"
+  }
+
+  def 'executeOp returns null without retrying on 404 Not Found'() {
+    given:
+    int callCount = 0
+    def ex = managementExceptionWithStatus(HttpURLConnection.HTTP_NOT_FOUND)
+
+    when:
+    def result = AzureBaseClient.executeOp({
+      callCount++
+      throw ex
+    }, 3L)
+
+    then: '404 is not retried — resource is gone, retrying cannot help'
+    result == null
+    callCount == 1
+  }
+
+  def 'executeOp throws after exhausting all retries on 409'() {
+    given:
+    def ex = managementExceptionWithStatus(HttpURLConnection.HTTP_CONFLICT)
+
+    when:
+    AzureBaseClient.executeOp({ throw ex }, 2L)
+
+    then:
+    def thrown = thrown(ManagementException)
+    thrown.is(ex)
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureBaseClientSpec.groovy
@@ -16,10 +16,7 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
-import com.azure.core.http.HttpResponse
 import com.azure.core.management.exception.ManagementException
-import org.mockito.Mockito
-import spock.lang.Specification
 import spock.lang.Unroll
 
 /**
@@ -28,13 +25,7 @@ import spock.lang.Unroll
  *
  * executeOp is a static method so no instance allocation is needed.
  */
-class AzureBaseClientSpec extends Specification {
-
-  private static ManagementException managementExceptionWithStatus(int statusCode) {
-    def httpResponse = Mockito.mock(HttpResponse)
-    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
-    new ManagementException("Simulated ${statusCode}", httpResponse)
-  }
+class AzureBaseClientSpec extends AzureClientSpecBase {
 
   @Unroll
   def 'executeOp retries and succeeds after a transient #label'() {

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureClientSpecBase.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureClientSpecBase.groovy
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2026 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.client
+
+import com.azure.core.http.HttpResponse
+import com.azure.core.management.exception.ManagementException
+import org.mockito.Mockito
+import spock.lang.Specification
+
+abstract class AzureClientSpecBase extends Specification {
+
+  protected static ManagementException managementExceptionWithStatus(int statusCode) {
+    def httpResponse = Mockito.mock(HttpResponse)
+    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
+    new ManagementException("Simulated ${statusCode}", httpResponse)
+  }
+
+  protected static sun.misc.Unsafe getUnsafe() {
+    def f = sun.misc.Unsafe.getDeclaredField("theUnsafe")
+    f.accessible = true
+    f.get(null) as sun.misc.Unsafe
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClientSpec.groovy
@@ -1,0 +1,95 @@
+/*
+ * Copyright 2026 The original authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.netflix.spinnaker.clouddriver.azure.client
+
+import com.azure.core.http.HttpResponse
+import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.compute.models.VirtualMachineScaleSet
+import org.mockito.MockedStatic
+import org.mockito.Mockito
+import spock.lang.Specification
+
+/**
+ * Tests for AzureComputeClient.resizeServerGroup.
+ *
+ * AzureComputeClient requires real Azure credentials at construction time, so we
+ * allocate an instance via Unsafe (bypassing the constructor) and mock the static
+ * AzureBaseClient.executeOp to control Azure SDK interactions.
+ */
+class AzureComputeClientSpec extends Specification {
+
+  private static ManagementException managementExceptionWithStatus(int statusCode) {
+    def httpResponse = Mockito.mock(HttpResponse)
+    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
+    new ManagementException("Simulated ${statusCode}", httpResponse)
+  }
+
+  private static AzureComputeClient allocateClient() {
+    def f = sun.misc.Unsafe.getDeclaredField("theUnsafe")
+    f.accessible = true
+    def unsafe = f.get(null) as sun.misc.Unsafe
+    unsafe.allocateInstance(AzureComputeClient) as AzureComputeClient
+  }
+
+  def 'resizeServerGroup calls executeOp for both get and apply when server group exists'() {
+    given:
+    def client = allocateClient()
+    // @CompileStatic in AzureComputeClient enforces the VirtualMachineScaleSet return type,
+    // so the mock must be typed accordingly even though executeOp closures are not executed.
+    def mockVmss = Mockito.mock(VirtualMachineScaleSet)
+
+    MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
+    // First call (getByResourceGroup) → return vmss; second call (apply) → return null (success)
+    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure)) })
+        .thenReturn(mockVmss)
+        .thenReturn(null)
+    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong()) })
+        .thenReturn(mockVmss)
+        .thenReturn(null)
+
+    when:
+    def result = client.resizeServerGroup("my-rg", "my-vmss", 0)
+
+    then: 'executeOp is called twice — once for the get, once for the apply()'
+    staticMock.verify({ AzureBaseClient.executeOp(Mockito.any(Closure)) }, Mockito.times(2))
+    result == null
+
+    cleanup:
+    staticMock.close()
+  }
+
+  def 'resizeServerGroup skips apply when server group is not found'() {
+    given:
+    def client = allocateClient()
+
+    MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
+    // Get returns null → server group not found; apply must not be called
+    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure)) }).thenReturn(null)
+    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong()) }).thenReturn(null)
+
+    when:
+    def result = client.resizeServerGroup("my-rg", "my-vmss", 0)
+
+    then: 'only the get executeOp call is made; no NPE from calling update() on null'
+    staticMock.verify({ AzureBaseClient.executeOp(Mockito.any(Closure)) }, Mockito.times(1))
+    result == null
+    noExceptionThrown()
+
+    cleanup:
+    staticMock.close()
+  }
+}

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureComputeClientSpec.groovy
@@ -16,78 +16,104 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
-import com.azure.core.http.HttpResponse
-import com.azure.core.management.exception.ManagementException
+import com.azure.resourcemanager.AzureResourceManager
 import com.azure.resourcemanager.compute.models.VirtualMachineScaleSet
 import org.mockito.MockedStatic
 import org.mockito.Mockito
-import spock.lang.Specification
+import org.mockito.stubbing.Answer
+
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Tests for AzureComputeClient.resizeServerGroup.
  *
  * AzureComputeClient requires real Azure credentials at construction time, so we
- * allocate an instance via Unsafe (bypassing the constructor) and mock the static
- * AzureBaseClient.executeOp to control Azure SDK interactions.
+ * allocate an instance via Unsafe (bypassing the constructor).
+ *
+ * Integration-level tests that exercise real executeOp retry logic inject a mocked
+ * AzureResourceManager directly into the azure field via Unsafe.
+ *
+ * Structural tests that need to verify the number of executeOp invocations mock
+ * AzureBaseClient.executeOp statically.
  */
-class AzureComputeClientSpec extends Specification {
-
-  private static ManagementException managementExceptionWithStatus(int statusCode) {
-    def httpResponse = Mockito.mock(HttpResponse)
-    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
-    new ManagementException("Simulated ${statusCode}", httpResponse)
-  }
+class AzureComputeClientSpec extends AzureClientSpecBase {
 
   private static AzureComputeClient allocateClient() {
-    def f = sun.misc.Unsafe.getDeclaredField("theUnsafe")
-    f.accessible = true
-    def unsafe = f.get(null) as sun.misc.Unsafe
-    unsafe.allocateInstance(AzureComputeClient) as AzureComputeClient
+    getUnsafe().allocateInstance(AzureComputeClient) as AzureComputeClient
   }
 
-  def 'resizeServerGroup calls executeOp for both get and apply when server group exists'() {
+  private static void injectAzureField(AzureComputeClient client, AzureResourceManager azure) {
+    def azureField = AzureBaseClient.getDeclaredField("azure")
+    getUnsafe().putObject(client, getUnsafe().objectFieldOffset(azureField), azure)
+  }
+
+  // ---------------------------------------------------------------------------
+  // Integration tests — real executeOp, mocked Azure SDK
+  // ---------------------------------------------------------------------------
+
+  def 'resizeServerGroup re-fetches VMSS from Azure on each retry when apply throws 409'() {
+    given: 'a client whose azure field points at a mocked AzureResourceManager'
+    def client = allocateClient()
+    def conflictEx = managementExceptionWithStatus(HttpURLConnection.HTTP_CONFLICT)
+    def getCallCount = new AtomicInteger(0)
+
+    def mockVmss = Mockito.mock(VirtualMachineScaleSet, Mockito.RETURNS_DEEP_STUBS)
+    Mockito.when(mockVmss.update().withCapacity(Mockito.anyInt()).apply())
+        .thenThrow(conflictEx)
+        .thenReturn(mockVmss)
+
+    def mockAzure = Mockito.mock(AzureResourceManager, Mockito.RETURNS_DEEP_STUBS)
+    Mockito.when(mockAzure.virtualMachineScaleSets()
+        .getByResourceGroup(Mockito.anyString(), Mockito.anyString()))
+        .thenAnswer({ inv -> getCallCount.incrementAndGet(); mockVmss } as Answer)
+
+    injectAzureField(client, mockAzure)
+
+    when:
+    client.resizeServerGroup("my-rg", "my-vmss", 0)
+
+    then: 'the VMSS was re-fetched on the second attempt, proving get lives inside the retry closure'
+    getCallCount.get() == 2
+    noExceptionThrown()
+  }
+
+  def 'resizeServerGroup completes without exception when no server group is found'() {
     given:
     def client = allocateClient()
-    // @CompileStatic in AzureComputeClient enforces the VirtualMachineScaleSet return type,
-    // so the mock must be typed accordingly even though executeOp closures are not executed.
-    def mockVmss = Mockito.mock(VirtualMachineScaleSet)
 
-    MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
-    // First call (getByResourceGroup) → return vmss; second call (apply) → return null (success)
-    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure)) })
-        .thenReturn(mockVmss)
+    def mockAzure = Mockito.mock(AzureResourceManager, Mockito.RETURNS_DEEP_STUBS)
+    Mockito.when(mockAzure.virtualMachineScaleSets()
+        .getByResourceGroup(Mockito.anyString(), Mockito.anyString()))
         .thenReturn(null)
-    staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong()) })
-        .thenReturn(mockVmss)
-        .thenReturn(null)
+
+    injectAzureField(client, mockAzure)
 
     when:
     def result = client.resizeServerGroup("my-rg", "my-vmss", 0)
 
-    then: 'executeOp is called twice — once for the get, once for the apply()'
-    staticMock.verify({ AzureBaseClient.executeOp(Mockito.any(Closure)) }, Mockito.times(2))
+    then: 'null VMSS is handled gracefully — no NPE from update() on null'
     result == null
-
-    cleanup:
-    staticMock.close()
+    noExceptionThrown()
   }
 
-  def 'resizeServerGroup skips apply when server group is not found'() {
+  // ---------------------------------------------------------------------------
+  // Structural tests — executeOp mocked statically
+  // ---------------------------------------------------------------------------
+
+  def 'resizeServerGroup wraps the entire get-and-apply sequence in one executeOp call'() {
     given:
     def client = allocateClient()
 
     MockedStatic<AzureBaseClient> staticMock = Mockito.mockStatic(AzureBaseClient)
-    // Get returns null → server group not found; apply must not be called
     staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure)) }).thenReturn(null)
     staticMock.when({ AzureBaseClient.executeOp(Mockito.any(Closure), Mockito.anyLong()) }).thenReturn(null)
 
     when:
     def result = client.resizeServerGroup("my-rg", "my-vmss", 0)
 
-    then: 'only the get executeOp call is made; no NPE from calling update() on null'
+    then: 'exactly one executeOp call — get and apply share the same retryable closure'
     staticMock.verify({ AzureBaseClient.executeOp(Mockito.any(Closure)) }, Mockito.times(1))
     result == null
-    noExceptionThrown()
 
     cleanup:
     staticMock.close()

--- a/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClientSpec.groovy
+++ b/clouddriver/clouddriver-azure/src/test/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClientSpec.groovy
@@ -16,12 +16,9 @@
 
 package com.netflix.spinnaker.clouddriver.azure.client
 
-import com.azure.core.http.HttpResponse
-import com.azure.core.management.exception.ManagementException
 import org.mockito.MockedStatic
 import org.mockito.Mockito
 import org.mockito.invocation.InvocationOnMock
-import spock.lang.Specification
 
 /**
  * Tests for AzureNetworkClient.getAppGateway exception-handling logic.
@@ -30,30 +27,13 @@ import spock.lang.Specification
  * allocate an instance via Unsafe (bypassing the constructor) and then use
  * Mockito.mockStatic to intercept the static AzureBaseClient.executeOp method.
  */
-class AzureNetworkClientSpec extends Specification {
+class AzureNetworkClientSpec extends AzureClientSpecBase {
 
   static final String RESOURCE_GROUP = "my-rg"
   static final String AGW_NAME = "myapp-main-v001"
 
-  /**
-   * Create a ManagementException that fakes a given HTTP status code.
-   */
-  private static ManagementException managementExceptionWithStatus(int statusCode) {
-    def httpResponse = Mockito.mock(HttpResponse)
-    Mockito.when(httpResponse.getStatusCode()).thenReturn(statusCode)
-    new ManagementException("Simulated ${statusCode}", httpResponse)
-  }
-
-  /**
-   * Allocate an AzureNetworkClient without running AzureBaseClient's constructor
-   * (which would try to contact Azure). The azure field is left null but that is
-   * fine because executeOp will be mocked out before getAppGateway calls it.
-   */
   private static AzureNetworkClient allocateClient() {
-    def f = sun.misc.Unsafe.getDeclaredField("theUnsafe")
-    f.accessible = true
-    def unsafe = f.get(null) as sun.misc.Unsafe
-    unsafe.allocateInstance(AzureNetworkClient) as AzureNetworkClient
+    getUnsafe().allocateInstance(AzureNetworkClient) as AzureNetworkClient
   }
 
   def 'getAppGateway returns null for a 404 ManagementException'() {


### PR DESCRIPTION
## Summary

- Add HTTP 409 (Conflict) to `AzureBaseClient.canRetry()` so the retry harness backs off and retries on Azure concurrent write conflicts
- Merge the get + apply in `AzureComputeClient.resizeServerGroup()` into one `executeOp` closure, matching the pattern already established by the disable methods — retries now re-fetch a fresh VMSS reference rather than reusing a stale one

## Root cause

Investigated from pipeline execution `01KVE8QYGXK6TK349JW2E6SPVA` (`deploy-devaz` for `monitoringatlas2`, 2026-06-18 14:03 PDT). The `scaleDown` stage failed terminally with:

```
Status code 409, ConflictingConcurrentWriteNotAllowed
"The operation was interrupted by a conflicting concurrent write on the same entity. Please retry later."
```

Azure holds an exclusive write lock on a VMSS for the duration of any update. The `disableCluster` step completed from Spinnaker's perspective but the underlying Azure VMSS update was still in flight when `scaleDown` immediately issued a resize — hitting the lock and getting a 409. Azure explicitly documents this as transient and instructs callers to retry.

## Prior art — the single-closure pattern

Three existing methods in `AzureNetworkClient` already wrap the full read-modify-write sequence in one `executeOp` closure. `resizeServerGroup` now matches them:

- [`disableServerGroup` (app gateway path)](https://github.com/moderneinc/spinnaker/blob/ae328b3295c4a08a2ad6d38cf6edb9de1d44385b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy#L330-L358)
- [`disableServerGroupWithLoadBalancer`](https://github.com/moderneinc/spinnaker/blob/ae328b3295c4a08a2ad6d38cf6edb9de1d44385b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy#L420-L438)
- [`enableServerGroupWithAppGateway`](https://github.com/moderneinc/spinnaker/blob/ae328b3295c4a08a2ad6d38cf6edb9de1d44385b/clouddriver/clouddriver-azure/src/main/groovy/com/netflix/spinnaker/clouddriver/azure/client/AzureNetworkClient.groovy#L292-L328)

All three wrap `vmss.update().apply()` inside the same closure as the `getByResourceGroup` call, so a failed write retries the entire read-modify-write sequence with a fresh VMSS reference.

## Before

```mermaid
sequenceDiagram
    participant S as Spinnaker (Orca)
    participant CD as Clouddriver
    participant AZ as Azure VMSS API

    S->>CD: scaleDown(v054, capacity=0)
    CD->>AZ: getByResourceGroup(v054)
    Note over CD,AZ: inside executeOp() — retried on failure
    AZ-->>CD: 200 OK, vmss object
    CD->>AZ: vmss.update().withCapacity(0).apply()
    Note over CD,AZ: NOT inside executeOp() — no retry
    AZ-->>CD: 409 ConflictingConcurrentWriteNotAllowed
    Note over CD: ManagementException caught<br/>resourceNotFound? No → rethrow
    CD-->>S: AtomicOperationException
    S-->>S: Stage TERMINAL — pipeline fails
```

## After

```mermaid
sequenceDiagram
    participant S as Spinnaker (Orca)
    participant CD as Clouddriver
    participant AZ as Azure VMSS API

    S->>CD: scaleDown(v054, capacity=0)

    rect rgb(220, 240, 255)
        Note over CD,AZ: executeOp() — attempt 1
        CD->>AZ: getByResourceGroup(v054)
        AZ-->>CD: 200 OK, vmss object
        CD->>AZ: vmss.update().withCapacity(0).apply()
        AZ-->>CD: 409 ConflictingConcurrentWriteNotAllowed
        Note over CD: canRetry(409)? Yes → sleep(backoff)
    end

    rect rgb(220, 240, 255)
        Note over CD,AZ: executeOp() — attempt 2 (fresh VMSS fetch)
        CD->>AZ: getByResourceGroup(v054)
        AZ-->>CD: 200 OK, vmss object
        CD->>AZ: vmss.update().withCapacity(0).apply()
        AZ-->>CD: 200 OK
    end

    CD-->>S: success
    S-->>S: Stage SUCCEEDED — pipeline continues
```

## Test plan

- [ ] `AzureBaseClientSpec` — verifies `executeOp` retries on 409, 408, 5xx; does not retry on 404; throws after exhausting retries
- [ ] `AzureComputeClientSpec` — integration test verifies VMSS is re-fetched on each retry (proving get lives inside the closure); null guard verified; structural test verifies single `executeOp` call
- [ ] Deploy pipeline for an Azure tenant completes without manual intervention when `disableCluster` and `scaleDown` race
