### PR TITLE
fix(kork-atlas): bound Atlas metric cardinality (Phase 2)

### DIFF
--- a/kork/kork-atlas/kork-atlas.gradle
+++ b/kork/kork-atlas/kork-atlas.gradle
@@ -16,7 +16,6 @@ dependencies {
 
   implementation "software.amazon.awssdk:ec2"
   implementation "software.amazon.awssdk:regions"
-  implementation "org.kohsuke:wordnet-random-name:1.9"
 
   api "io.micrometer:micrometer-registry-atlas"
   api "io.micrometer:micrometer-core"

--- a/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfiguration.java
+++ b/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfiguration.java
@@ -36,6 +36,21 @@ public class AtlasMetricsAutoConfiguration {
     return registry -> registry.config().meterFilter(baseUnitMeterFilter());
   }
 
+  /**
+   * Defensive backstop: cap the number of distinct meters the Atlas registry will hold so a runaway
+   * high-cardinality source degrades gracefully (new meters denied) instead of growing the publish
+   * set until the JVM OOMs. Tune via {@code moderne.atlas.max-metrics}.
+   */
+  @Bean
+  MeterRegistryCustomizer<AtlasMeterRegistry> atlasMaxMetricsGuard(
+      @Value("${moderne.atlas.max-metrics:50000}") int maxMetrics) {
+    return registry -> registry.config().meterFilter(maximumMetricsFilter(maxMetrics));
+  }
+
+  static MeterFilter maximumMetricsFilter(int maxMetrics) {
+    return MeterFilter.maximumAllowableMetrics(maxMetrics);
+  }
+
   static MeterFilter baseUnitMeterFilter() {
     return new MeterFilter() {
       @Override

--- a/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfiguration.java
+++ b/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfiguration.java
@@ -4,6 +4,8 @@ import io.micrometer.atlas.AtlasMeterRegistry;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.config.MeterFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
@@ -25,6 +27,9 @@ import org.springframework.context.annotation.PropertySource;
 @PropertySource("classpath:kork-atlas.properties")
 public class AtlasMetricsAutoConfiguration {
 
+  private static final Logger log = LoggerFactory.getLogger(AtlasMetricsAutoConfiguration.class);
+  static final int DEFAULT_MAX_METRICS = 50_000;
+
   @Bean
   MeterFilter moderneCommonTags(
       @Value("${spring.application.name:unknown}") String applicationName) {
@@ -39,15 +44,34 @@ public class AtlasMetricsAutoConfiguration {
   /**
    * Defensive backstop: cap the number of distinct meters the Atlas registry will hold so a runaway
    * high-cardinality source degrades gracefully (new meters denied) instead of growing the publish
-   * set until the JVM OOMs. Tune via {@code moderne.atlas.max-metrics}.
+   * set until the JVM OOMs. Tune via {@code moderne.atlas.max-metrics}; a non-positive value
+   * disables the cap rather than denying every meter.
    */
   @Bean
   MeterRegistryCustomizer<AtlasMeterRegistry> atlasMaxMetricsGuard(
-      @Value("${moderne.atlas.max-metrics:50000}") int maxMetrics) {
-    return registry -> registry.config().meterFilter(maximumMetricsFilter(maxMetrics));
+      @Value("${moderne.atlas.max-metrics:50000}") String maxMetrics) {
+    return registry ->
+        registry.config().meterFilter(maximumMetricsFilter(parseMaxMetrics(maxMetrics)));
+  }
+
+  static int parseMaxMetrics(String value) {
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException | NullPointerException e) {
+      log.warn(
+          "Invalid moderne.atlas.max-metrics '{}'; using default {}", value, DEFAULT_MAX_METRICS);
+      return DEFAULT_MAX_METRICS;
+    }
   }
 
   static MeterFilter maximumMetricsFilter(int maxMetrics) {
+    if (maxMetrics <= 0) {
+      // A cap of 0 would deny the very first meter and silently zero out all telemetry. Treat any
+      // non-positive value as "disabled" so a misconfiguration degrades to no-cap, not no-metrics.
+      log.warn(
+          "moderne.atlas.max-metrics={} is non-positive; Atlas meter cap disabled", maxMetrics);
+      return new MeterFilter() {};
+    }
     return MeterFilter.maximumAllowableMetrics(maxMetrics);
   }
 

--- a/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTags.java
+++ b/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTags.java
@@ -43,6 +43,10 @@ public final class Ec2CommonTags {
     putIfNotBlank(tags, "stack", names.getStack());
     String detail = names.getDetail();
     tags.put("detail", (detail != null && !detail.isBlank()) ? detail : "none");
+    // server.group is the version-suffixed ASG name. Its cross-deploy growth is retention-bounded
+    // (old generations age out as their JVMs die) and the global meter cap is the OOM backstop, so
+    // it is kept for per-version attribution rather than dropped.
+    putIfNotBlank(tags, "server.group", names.getGroup());
     return tags;
   }
 
@@ -106,7 +110,7 @@ public final class Ec2CommonTags {
     }
 
     // Discover ASG name via DescribeTags filtered on the instance id;
-    // Frigga-parse it to fill in application/cluster/stack/detail.
+    // Frigga-parse it to fill in application/cluster/stack/detail/server.group.
     // Skip when instanceId or region is missing: instanceId-null would NPE in Filter builder
     // validation and would burn an EC2 API call against a throttled endpoint; region-null would
     // make Ec2Client.builder() re-walk the SDK region-resolution chain (incl. another IMDS hit

--- a/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTags.java
+++ b/kork/kork-atlas/src/main/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTags.java
@@ -12,7 +12,6 @@ import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.kohsuke.randname.RandomNameGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.regions.Region;
@@ -33,7 +32,6 @@ public final class Ec2CommonTags {
     tags.put("application", applicationName);
     tags.put("environment", "local");
     tags.put("instance.id", hostname());
-    tags.put("instance.display.name", new RandomNameGenerator().next());
     return tags;
   }
 
@@ -45,7 +43,6 @@ public final class Ec2CommonTags {
     putIfNotBlank(tags, "stack", names.getStack());
     String detail = names.getDetail();
     tags.put("detail", (detail != null && !detail.isBlank()) ? detail : "none");
-    putIfNotBlank(tags, "server.group", names.getGroup());
     return tags;
   }
 
@@ -107,10 +104,9 @@ public final class Ec2CommonTags {
     if (az != null) {
       tags.put("availability.zone", az);
     }
-    tags.put("instance.display.name", new RandomNameGenerator().next());
 
     // Discover ASG name via DescribeTags filtered on the instance id;
-    // Frigga-parse it to fill in application/cluster/stack/detail/server.group.
+    // Frigga-parse it to fill in application/cluster/stack/detail.
     // Skip when instanceId or region is missing: instanceId-null would NPE in Filter builder
     // validation and would burn an EC2 API call against a throttled endpoint; region-null would
     // make Ec2Client.builder() re-walk the SDK region-resolution chain (incl. another IMDS hit

--- a/kork/kork-atlas/src/main/resources/kork-atlas.properties
+++ b/kork/kork-atlas/src/main/resources/kork-atlas.properties
@@ -9,3 +9,8 @@ management.atlas.metrics.export.uri=${MODERNE_ATLAS_URI:http://localhost:7101/ap
 # Module ships dormant. The deploy mechanism flips both this and
 # MODERNE_ATLAS_URI when the labs Atlas endpoint is ready.
 management.atlas.metrics.export.enabled=false
+
+# Defensive cardinality backstop: the Atlas registry refuses to register new meters beyond this
+# count, so a runaway high-cardinality source degrades gracefully instead of growing the publish
+# set until the JVM OOMs. Generous default that should not trigger in normal operation.
+moderne.atlas.max-metrics=50000

--- a/kork/kork-atlas/src/main/resources/kork-atlas.properties
+++ b/kork/kork-atlas/src/main/resources/kork-atlas.properties
@@ -12,5 +12,6 @@ management.atlas.metrics.export.enabled=false
 
 # Defensive cardinality backstop: the Atlas registry refuses to register new meters beyond this
 # count, so a runaway high-cardinality source degrades gracefully instead of growing the publish
-# set until the JVM OOMs. Generous default that should not trigger in normal operation.
+# set until the JVM OOMs. Generous default that should not trigger in normal operation. A blank or
+# non-numeric value falls back to the default; a non-positive value disables the cap.
 moderne.atlas.max-metrics=50000

--- a/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfigurationTest.java
+++ b/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfigurationTest.java
@@ -2,7 +2,9 @@ package io.moderne.spinnaker.kork.atlas;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.netflix.spectator.atlas.AtlasConfig;
 import io.micrometer.atlas.AtlasMeterRegistry;
+import io.micrometer.core.instrument.Clock;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
@@ -107,5 +109,57 @@ class AtlasMetricsAutoConfigurationTest {
     assertThat(registry.find("meter.one").counter()).isNotNull();
     assertThat(registry.find("meter.two").counter()).isNotNull();
     assertThat(registry.find("meter.three").counter()).isNull();
+  }
+
+  @Test
+  void maximumMetricsFilter_withNonPositiveLimit_disablesTheCapInsteadOfDenyingEverything() {
+    // A misconfigured cap of 0 (or negative) must NOT silently drop all telemetry; it disables
+    // the backstop and accepts meters as normal.
+    MeterFilter guard = AtlasMetricsAutoConfiguration.maximumMetricsFilter(0);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    registry.config().meterFilter(guard);
+
+    registry.counter("a");
+    registry.counter("b");
+    registry.counter("c");
+
+    assertThat(registry.find("a").counter()).isNotNull();
+    assertThat(registry.find("c").counter()).isNotNull();
+  }
+
+  @Test
+  void parseMaxMetrics_fallsBackToDefaultOnBlankOrNonNumericValue() {
+    assertThat(AtlasMetricsAutoConfiguration.parseMaxMetrics("100")).isEqualTo(100);
+    assertThat(AtlasMetricsAutoConfiguration.parseMaxMetrics("  250 ")).isEqualTo(250);
+    assertThat(AtlasMetricsAutoConfiguration.parseMaxMetrics("")).isEqualTo(50_000);
+    assertThat(AtlasMetricsAutoConfiguration.parseMaxMetrics("   ")).isEqualTo(50_000);
+    assertThat(AtlasMetricsAutoConfiguration.parseMaxMetrics("not-a-number")).isEqualTo(50_000);
+  }
+
+  @Test
+  void maxMetricsGuard_actuallyCapsMetersWhenAppliedToAnAtlasMeterRegistry() {
+    AtlasConfig nonPublishing =
+        new AtlasConfig() {
+          @Override
+          public String get(String key) {
+            return null;
+          }
+
+          @Override
+          public boolean autoStart() {
+            return false;
+          }
+        };
+    AtlasMeterRegistry registry = new AtlasMeterRegistry(nonPublishing, Clock.SYSTEM);
+    new AtlasMetricsAutoConfiguration().atlasMaxMetricsGuard("2").customize(registry);
+
+    registry.counter("a");
+    registry.counter("b");
+    registry.counter("c"); // beyond the cap
+
+    assertThat(registry.find("a").counter()).isNotNull();
+    assertThat(registry.find("b").counter()).isNotNull();
+    assertThat(registry.find("c").counter()).isNull();
+    registry.close();
   }
 }

--- a/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfigurationTest.java
+++ b/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/AtlasMetricsAutoConfigurationTest.java
@@ -6,6 +6,7 @@ import io.micrometer.atlas.AtlasMeterRegistry;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.config.MeterFilter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.actuate.autoconfigure.metrics.MeterRegistryCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
@@ -39,13 +40,24 @@ class AtlasMetricsAutoConfigurationTest {
   }
 
   @Test
-  void neitherBeanIsWiredWhenAtlasRegistryIsAbsent() {
+  void wiresMaxMetricsGuardWhenAtlasRegistryOnClasspath() {
+    contextRunner.run(
+        context -> {
+          assertThat(context).hasBean("atlasMaxMetricsGuard");
+          assertThat(context.getBean("atlasMaxMetricsGuard"))
+              .isInstanceOf(MeterRegistryCustomizer.class);
+        });
+  }
+
+  @Test
+  void noBeansAreWiredWhenAtlasRegistryIsAbsent() {
     contextRunner
         .withClassLoader(new FilteredClassLoader(AtlasMeterRegistry.class))
         .run(
             context -> {
               assertThat(context).doesNotHaveBean("moderneCommonTags");
               assertThat(context).doesNotHaveBean("atlasBaseUnitTagCustomizer");
+              assertThat(context).doesNotHaveBean("atlasMaxMetricsGuard");
             });
   }
 
@@ -80,5 +92,20 @@ class AtlasMetricsAutoConfigurationTest {
     Meter.Id mapped = AtlasMetricsAutoConfiguration.baseUnitMeterFilter().map(id);
 
     assertThat(mapped.getTag("baseUnit")).isNull();
+  }
+
+  @Test
+  void maximumMetricsFilter_deniesNewMetersBeyondTheConfiguredLimit() {
+    MeterFilter guard = AtlasMetricsAutoConfiguration.maximumMetricsFilter(2);
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    registry.config().meterFilter(guard);
+
+    registry.counter("meter.one");
+    registry.counter("meter.two");
+    registry.counter("meter.three"); // beyond the cap — must be denied, not OOM the backend
+
+    assertThat(registry.find("meter.one").counter()).isNotNull();
+    assertThat(registry.find("meter.two").counter()).isNotNull();
+    assertThat(registry.find("meter.three").counter()).isNull();
   }
 }

--- a/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTagsTest.java
+++ b/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTagsTest.java
@@ -32,10 +32,7 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("cluster", "clouddriver-prod");
     assertThat(tags).containsEntry("stack", "prod");
     assertThat(tags).containsEntry("detail", "none");
-    // server.group is the version-suffixed ASG name (e.g. ...-v001): unbounded common-tag
-    // cardinality, +1 distinct series every red/black deploy. cluster gives the stable
-    // grouping, so server.group must not be emitted as a common tag.
-    assertThat(tags).doesNotContainKey("server.group");
+    assertThat(tags).containsEntry("server.group", "clouddriver-prod-v001");
   }
 
   @Test
@@ -45,7 +42,7 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("application", "clouddriver");
     assertThat(tags).containsEntry("cluster", "clouddriver");
     assertThat(tags).containsEntry("detail", "none");
-    assertThat(tags).doesNotContainKey("server.group");
+    assertThat(tags).containsEntry("server.group", "clouddriver");
   }
 
   @Test
@@ -110,7 +107,7 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("application", "clouddriver");
     assertThat(tags).containsEntry("stack", "prod");
     assertThat(tags).containsEntry("detail", "canary");
-    assertThat(tags).doesNotContainKey("server.group");
+    assertThat(tags).containsEntry("server.group", "clouddriver-prod-canary-v007");
   }
 
   private static String expectedHostname() {

--- a/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTagsTest.java
+++ b/kork/kork-atlas/src/test/java/io/moderne/spinnaker/kork/atlas/Ec2CommonTagsTest.java
@@ -18,8 +18,9 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("application", "clouddriver");
     assertThat(tags).containsEntry("environment", "local");
     assertThat(tags).containsKey("instance.id");
-    assertThat(tags).containsKey("instance.display.name");
-    assertThat(tags.get("instance.display.name")).isNotBlank();
+    // instance.display.name is a per-process RandomNameGenerator value: unbounded cardinality
+    // (a fresh value every restart) with no diagnostic worth. It must not be emitted.
+    assertThat(tags).doesNotContainKey("instance.display.name");
     assertThat(tags.get("instance.id")).isEqualTo(expectedHostname());
   }
 
@@ -31,7 +32,10 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("cluster", "clouddriver-prod");
     assertThat(tags).containsEntry("stack", "prod");
     assertThat(tags).containsEntry("detail", "none");
-    assertThat(tags).containsEntry("server.group", "clouddriver-prod-v001");
+    // server.group is the version-suffixed ASG name (e.g. ...-v001): unbounded common-tag
+    // cardinality, +1 distinct series every red/black deploy. cluster gives the stable
+    // grouping, so server.group must not be emitted as a common tag.
+    assertThat(tags).doesNotContainKey("server.group");
   }
 
   @Test
@@ -41,7 +45,7 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("application", "clouddriver");
     assertThat(tags).containsEntry("cluster", "clouddriver");
     assertThat(tags).containsEntry("detail", "none");
-    assertThat(tags).containsEntry("server.group", "clouddriver");
+    assertThat(tags).doesNotContainKey("server.group");
   }
 
   @Test
@@ -106,7 +110,7 @@ class Ec2CommonTagsTest {
     assertThat(tags).containsEntry("application", "clouddriver");
     assertThat(tags).containsEntry("stack", "prod");
     assertThat(tags).containsEntry("detail", "canary");
-    assertThat(tags).containsEntry("server.group", "clouddriver-prod-canary-v007");
+    assertThat(tags).doesNotContainKey("server.group");
   }
 
   private static String expectedHostname() {


### PR DESCRIPTION
## What

Phase 2 of the Spinnaker→Atlas observability roadmap (moderne-saas#885): bound the metric cardinality the labs Spinnaker services publish, now that emission is live (#119 / infra#1856).

**Drop one unbounded, worthless common tag:**
- **`instance.display.name`** — a per-process `RandomNameGenerator` value, minted fresh on every restart. Unbounded over time, zero diagnostic worth. (Also removes the now-unused `org.kohsuke:wordnet-random-name` dependency.)

**Add a defensive meter backstop** — `MeterFilter.maximumAllowableMetrics`, default **50 000** (tunable via `moderne.atlas.max-metrics`), gated on the Atlas registry. If a runaway high-cardinality source ever appears, new meters are denied rather than growing the publish set until the JVM OOMs. Hardened against misconfiguration: a non-positive value **disables** the cap (rather than denying every meter), and a blank/non-numeric value falls back to the default with a logged warning (rather than failing service startup).

**`server.group` is kept** (was briefly dropped in an earlier revision of this PR, now restored). It's retained for per-version attribution. Its cross-deploy growth is *retention-bounded* — old server-group generations age out of Atlas as their JVMs die — and a per-JVM tag cap couldn't bound it anyway (a common tag has exactly one value per process). The global meter cap above is the real OOM guard.

## Why

Grounded in a live audit of the labs Atlas reader (`labsatlasreader2`), captured in moderne-saas#1417. Spinnaker currently emits ~270 metric names under `application=spinnaker`; the federated reader shares a cardinality budget across the whole labs estate, and an unbounded-tag explosion in a sibling service (the Connector, moderne-saas#1348) has already taken the read-side Atlas down. `instance.display.name` is a purely-wasteful per-restart vector; the meter cap is the general backstop against the Connector failure class.

## Scope

In: the `instance.display.name` removal + the meter backstop.
**Out (deliberately):** the dot↔camelCase key normalization, `cloudProvider` case (`AWS` vs `aws`), and `region` null values. Those are estate-wide and couple to the #1401 dashboards, so they're tracked separately in #1417.

Confirmed against #1401: no dashboard slices on `server.group` or `instance.display.name`, so the one removal breaks no charts.

## Test plan

- `./gradlew :kork:kork-atlas:build` green on JDK 17 (compile + spotless + 20 tests, 0 failures).
- TDD throughout: tag-presence/absence assertions; a cap behavior test; a guard test against a real (publish-disabled) `AtlasMeterRegistry`; non-positive-disables and parse-fallback tests.

## Status

Draft while the live diagnosis / list-pull continues.

Refs: moderne-saas#885 (roadmap), moderne-saas#1417 (Phase 2 + audit), moderne-saas#1348 (cardinality precedent), moderne-saas#1401 (dashboards), #119 (Phase 1).
